### PR TITLE
27 handle performance bottleneck with searching dataset absolute paths

### DIFF
--- a/src/deepaudiox/datasets/audio_classification_dataset.py
+++ b/src/deepaudiox/datasets/audio_classification_dataset.py
@@ -19,35 +19,31 @@ class AudioClassificationDataset(Dataset):
     item returned by the dataset contains the label; label id, and the waveform of the audio as numpy array.
 
     Attributes:
-        root_dir (str): Root directory containing the audio files.
+        file_to_class_mapping (dict): Mapping from file paths to class names.
         sample_rate (int): Target sampling rate for audio loading.
         class_mapping (dict): Mapping from string labels to integer IDs.
-
     """
 
     def __init__(
         self,
-        root_dir: str | Path,
+        file_to_class_mapping: dict[str, str],
         sample_rate: int,
         class_mapping: dict[str, int],
-        instance_metadata: list[dict] | None = None,
         segment_duration: float | None = None,
     ):
         """Initialize the dataset.
 
         Args:
-            root_dir (str): Root directory containing the audio files.
+            file_to_class_mapping (dict): Mapping from file paths to class names.
             sample_rate (int): Target sampling rate for audio loading.
             class_mapping (dict): Mapping from string labels to integer IDs.
             segment_duration (float | None): Duration of audio segments in seconds. If None, load full audio.
-            drop_corrupted (bool): Whether to drop corrupted audio files. Defaults to False.
         """
-        self.root_dir = Path(root_dir)
-        if not self.root_dir.is_dir():
-            raise ValueError(f"The path '{self.root_dir}' is not a directory")
 
-        self.absolute_paths = list(self.root_dir.rglob("*.wav")) + list(self.root_dir.rglob("*.mp3"))
-        self.instances = self._load_instance_paths_and_classes(instance_metadata)
+        self.file_to_class_mapping = file_to_class_mapping
+        self.instances = [
+            {"path": Path(path), "class_name": class_name} for path, class_name in file_to_class_mapping.items()
+        ]
         self.segment_map = []
 
         self.sample_rate = sample_rate
@@ -56,45 +52,6 @@ class AudioClassificationDataset(Dataset):
 
         if self.segment_duration is not None:
             self.segmentize_audios(self.segment_duration)
-
-    def _load_instance_paths_and_classes(self, instance_metadata: list[dict] | None) -> list[dict[str, str]]:
-        """Load metadata of dataset instances.
-
-        Args:
-            instance_metadata (list[dict]): List of metadata for instances to be loaded
-
-        Returns:
-            list: List of dictionaries with keys 'file_path' and 'label'.
-
-        """
-        instances = []
-
-        # ---- Case A: Metadata provided ----
-        if instance_metadata:
-            for meta in instance_metadata:
-                if "file_name" not in meta or "class_name" not in meta:
-                    raise ValueError("Metadata items must contain 'file_name' and 'class_name'.")
-
-                file_name = meta["file_name"]
-
-                for abs_path in self.absolute_paths:
-                    abs_path = Path(abs_path)
-
-                    if abs_path.name.endswith(file_name):
-                        instances.append({"path": abs_path, "class_name": meta["class_name"]})
-
-            return instances
-
-        # ---- Case B: Infer from folder structure ----
-        for subdir in self.root_dir.iterdir():
-            if subdir.is_dir():
-                class_name = subdir.name
-
-                for file_type in ("*.wav", "*.mp3"):
-                    for audio_file in subdir.rglob(file_type):
-                        instances.append({"path": audio_file, "class_name": class_name})
-
-        return instances
 
     def __len__(self) -> int:
         """Return the number of items in the dataset.
@@ -163,3 +120,62 @@ class AudioClassificationDataset(Dataset):
                 self.segment_map.append(
                     {"file_path": item["path"], "class_name": item["class_name"], "segment_idx": seg_idx}
                 )
+
+
+def audio_classification_dataset_from_dir(
+    root_dir: str,
+    sample_rate: int,
+    class_mapping: dict[str, int],
+    segment_duration: float | None = None,
+) -> AudioClassificationDataset:
+    """Create an AudioClassificationDataset from a directory structure.
+
+    Args:
+        root_dir (str | Path): Root directory containing class sub-folders.
+        sample_rate (int): Target sampling rate for audio loading.
+        class_mapping (dict): Mapping from string labels to integer IDs.
+        segment_duration (float | None): Duration of audio segments in seconds. If None, load full audio.
+
+    Returns:
+        AudioClassificationDataset: The constructed dataset.
+    """
+    root_path = Path(root_dir)
+    file_to_class_mapping = {}
+
+    subdirs = [d for d in root_path.iterdir() if d.is_dir()]
+    for _idx, subdir in enumerate(sorted(subdirs)):
+        audio_files = list(subdir.glob("**/*.wav")) + list(subdir.glob("**/*.mp3"))
+        for audio_file in audio_files:
+            file_to_class_mapping[audio_file] = subdir.name
+
+    return AudioClassificationDataset(
+        file_to_class_mapping=file_to_class_mapping,
+        sample_rate=sample_rate,
+        class_mapping=class_mapping,
+        segment_duration=segment_duration,
+    )
+
+
+def audio_classification_dataset_from_dictionary(
+    file_to_class_mapping: dict[str, str],
+    sample_rate: int,
+    class_mapping: dict[str, int],
+    segment_duration: float | None = None,
+) -> AudioClassificationDataset:
+    """Create an AudioClassificationDataset from a file-to-class mapping dictionary.
+
+    Args:
+        file_to_class_mapping (dict): Mapping from file paths to class names.
+        sample_rate (int): Target sampling rate for audio loading.
+        class_mapping (dict): Mapping from string labels to integer IDs.
+        segment_duration (float | None): Duration of audio segments in seconds. If None, load full audio.
+
+    Returns:
+        AudioClassificationDataset: The constructed dataset.
+    """
+    return AudioClassificationDataset(
+        file_to_class_mapping=file_to_class_mapping,
+        sample_rate=sample_rate,
+        class_mapping=class_mapping,
+        segment_duration=segment_duration,
+    )

--- a/src/deepaudiox/loops/trainer.py
+++ b/src/deepaudiox/loops/trainer.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.optim.lr_scheduler import LRScheduler, StepLR
+from torch.optim.lr_scheduler import LRScheduler
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -110,7 +110,7 @@ class Trainer:
         self.optimizer = optimizer
 
         # Configure scheduler
-        self.scheduler = lr_scheduler or StepLR(self.optimizer, step_size=20, gamma=0.1)
+        self.scheduler = lr_scheduler
 
         # Configure loss function
         self.loss_function = loss_function or nn.CrossEntropyLoss()
@@ -154,7 +154,9 @@ class Trainer:
                         self.optimizer.step()
 
                     train_loss /= len(self.train_dloader)
-                    self.scheduler.step()
+
+                    if self.scheduler:
+                        self.scheduler.step()
 
                 # Execute validation loop
                 self.model.eval()

--- a/src/deepaudiox/utils/training_utils.py
+++ b/src/deepaudiox/utils/training_utils.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 from torch import Generator, default_generator, randperm
+from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import Subset
 
 from deepaudiox.datasets.audio_classification_dataset import AudioClassificationDataset
@@ -76,23 +76,12 @@ def pad_collate_fn(batch) -> dict:
 
     """
     # Extract data
-    features = [item["feature"] for item in batch]
+    features = [torch.from_numpy(item["feature"]) for item in batch]
     labels = torch.tensor([item["class_id"] for item in batch], dtype=torch.long)
     class_names = [item["class_name"] for item in batch]
 
-    # Ensure features are tensors
-    features = [torch.as_tensor(f) for f in features]
-
-    # Find max length in this batch
-    max_len = max(f.shape[-1] for f in features)
-
-    # Pad each tensor to max_len
-    padded_features = [
-        F.pad(f, (0, max_len - f.shape[-1])) if f.shape[-1] < max_len else f[..., :max_len] for f in features
-    ]
-
-    # Stack into a single batch tensor: (batch_size, num_channels, num_samples)
-    batch_features = torch.stack(padded_features)
+    # Stack into a single batch tensor with padding zeros on right to max_len
+    batch_features = pad_sequence(features, batch_first=True)
 
     return {"feature": batch_features, "class_id": labels, "class_name": class_names}
 

--- a/tests/test_audio_classification_dataset.py
+++ b/tests/test_audio_classification_dataset.py
@@ -4,7 +4,7 @@ import torch
 import torchaudio
 from torch.utils.data import random_split
 
-from deepaudiox.datasets.audio_classification_dataset import AudioClassificationDataset
+from deepaudiox.datasets.audio_classification_dataset import audio_classification_dataset_from_dir
 from deepaudiox.utils.training_utils import get_class_mapping
 
 torchaudio.set_audio_backend("soundfile")
@@ -36,7 +36,7 @@ def test_dataset_splits_counts(mock_audio_dataset):
     train_dir, test_dir = mock_audio_dataset
     class_mapping = get_class_mapping(train_dir)
 
-    dataset = AudioClassificationDataset(root_dir=train_dir, sample_rate=16000, class_mapping=class_mapping)
+    dataset = audio_classification_dataset_from_dir(root_dir=train_dir, sample_rate=16000, class_mapping=class_mapping)
 
     train_dset, val_dset = random_split(dataset, [0.9, 0.1])
 
@@ -48,7 +48,7 @@ def test_item_data_types(mock_audio_dataset):
     train_dir, test_dir = mock_audio_dataset
     class_mapping = get_class_mapping(train_dir)
 
-    dataset = AudioClassificationDataset(root_dir=train_dir, sample_rate=16000, class_mapping=class_mapping)
+    dataset = audio_classification_dataset_from_dir(root_dir=train_dir, sample_rate=16000, class_mapping=class_mapping)
 
     print(dataset[0]["feature"])
 
@@ -62,7 +62,7 @@ def test_segmentization(mock_audio_dataset, segment_duration):
     train_dir, test_dir = mock_audio_dataset
     class_mapping = get_class_mapping(train_dir)
 
-    dataset = AudioClassificationDataset(
+    dataset = audio_classification_dataset_from_dir(
         root_dir=train_dir, sample_rate=16000, class_mapping=class_mapping, segment_duration=segment_duration
     )
 


### PR DESCRIPTION
Stefane I made the changes on the AudioClassificationDataset.

Now the role of `instance_metadata` is handled by `file_to_class_mapping` which is a dictionary of the form `{"abs_path_to_filename": "class_name"}` mapping its wavfile (or mp3) to its corresponding class.

In addition, two auxiliary functions `audio_classification_dataset_from_dictionary`, `audio_classification_dataset_from_dir` were created to handle the case where:

1. The user defines the `file_to_class_mapping` in beforehand
2. The user provides the path to the folder structure of the data and the `file_to_class_mapping` is inferred by the structure of the specified directory.

Check @stefanos-vlachos 