### PR TITLE
39 integrate passt as backbone updated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.11", "3.12", "3.13" ]
 
     name: Test deepaudiox on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     name: Test deepaudiox on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.11", "3.12", "3.13" ]
+        python-version: [ "3.11", "3.12", "3.13", "3.14" ]
 
     name: Test deepaudiox on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "numpy>=2.3.3",
     "platformdirs>=4.5.0",
     "soundfile>=0.13.1",
+    "timm>=1.0.24",
     "torch>=2.8.0",
     "torchaudio>=2.8.0",
     "tqdm>=4.67.1",
@@ -30,7 +31,8 @@ dev = [
 # Set the maximum line length to 120
 line-length = 120
 exclude = [
-    "src/deepaudiox/modules/backbones/beats/beats_modules"
+    "src/deepaudiox/modules/backbones/beats/beats_modules",
+    "src/deepaudiox/modules/backbones/passt"
 ]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
   { name = "Stefanos Vlachos", email = "stevenvlaxos@gmail.com " }, 
   { name = "Ellie Vakalaki", email = "evakalakiaidl@gmail.com" }
 ]
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "numpy>=2.3.3",
     "platformdirs>=4.5.0",
     "soundfile>=0.13.1",
-    "timm>=1.0.24",
     "torch>=2.8.0",
     "torchaudio>=2.8.0",
     "tqdm>=4.67.1",
@@ -31,8 +30,7 @@ dev = [
 # Set the maximum line length to 120
 line-length = 120
 exclude = [
-    "src/deepaudiox/modules/backbones/beats/beats_modules",
-    "src/deepaudiox/modules/backbones/passt"
+    
 ]
 
 [tool.ruff.lint]

--- a/src/deepaudiox/modules/audio_classifier_constructor.py
+++ b/src/deepaudiox/modules/audio_classifier_constructor.py
@@ -27,7 +27,7 @@ class AudioClassifierConstructor(BaseAudioClassifier):
     def __init__(
         self,
         num_classes: int,
-        backbone: Literal["beats"] | BaseBackbone,
+        backbone: Literal["beats", "passt"] | BaseBackbone,
         pooling: Literal["gap", "simpool", "ep"] | BasePooling | None = None,
         freeze_backbone: bool = False,
         sample_rate: int = 16000,
@@ -83,7 +83,7 @@ class AudioClassifierConstructor(BaseAudioClassifier):
         )
 
     def _resolve_backbone(
-        self, backbone: Literal["beats"] | BaseBackbone, pretrained: bool, sample_rate: int
+        self, backbone: Literal["beats", "passt"] | BaseBackbone, pretrained: bool, sample_rate: int
     ) -> BaseBackbone:
         """Resolve backbone from literal or BaseBackbone instance.
 

--- a/src/deepaudiox/modules/backbones/__init__.py
+++ b/src/deepaudiox/modules/backbones/__init__.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 from deepaudiox.modules.backbones.base_backbone import BaseBackbone as Backbone
 from deepaudiox.modules.backbones.beats.beats_modules.BEATs import BEATs
+from deepaudiox.modules.backbones.passt.passt import PaSST
 
 # A dictionary mapping backbone names to their constructor functions
 BACKBONES: dict[str, Callable[[], Backbone]] = {}
@@ -25,3 +26,8 @@ def register_backbone(name: str):
 def beats_base() -> BEATs:
     """BEATs backbone without DivEncLayer."""
     return BEATs()
+
+@register_backbone("passt")
+def passt_base() -> PaSST:
+    """PaSST backbone"""
+    return PaSST()

--- a/src/deepaudiox/modules/backbones/__init__.py
+++ b/src/deepaudiox/modules/backbones/__init__.py
@@ -27,6 +27,7 @@ def beats_base() -> BEATs:
     """BEATs backbone without DivEncLayer."""
     return BEATs()
 
+
 @register_backbone("passt")
 def passt_base() -> PaSST:
     """PaSST backbone"""

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/BEATs.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/BEATs.py
@@ -65,7 +65,10 @@ class BEATsConfig:
 
 class BEATs(BaseBackbone):
     def __init__(
-        self, cfg: BEATsConfig = BEATsConfig(), preprocess_flag: bool = True, sample_rate: int = 16_000
+        self, 
+        cfg: BEATsConfig = BEATsConfig(), 
+        preprocess_flag: bool = True, 
+        sample_rate: int = 16_000
     ) -> None:
         super().__init__(out_dim=768, sample_rate=sample_rate)
 

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/BEATs.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/BEATs.py
@@ -50,6 +50,7 @@ class BEATsConfig:
         predictor_dropout (float): Dropout probability for the predictor.
         predictor_class (int): Number of target classes for predictor.
     """
+
     def __init__(self, cfg=None):
         self.input_patch_size: int = 16
         self.embed_dim: int = 512
@@ -101,12 +102,8 @@ class BEATs(BaseBackbone):
         preprocess_flag (bool): Whether to perform preprocessing on input waveforms.
         sample_rate (int): Sampling rate of input audio.
     """
-    def __init__(
-        self, 
-        cfg: BEATsConfig | None = None, 
-        preprocess_flag: bool = True, 
-        sample_rate: int = 16_000
-    ) -> None:
+
+    def __init__(self, cfg: BEATsConfig | None = None, preprocess_flag: bool = True, sample_rate: int = 16_000) -> None:
         super().__init__(out_dim=768, sample_rate=sample_rate)
 
         if cfg is None:
@@ -119,9 +116,7 @@ class BEATs(BaseBackbone):
 
         self.embed = self.cfg.embed_dim
         self.post_extract_proj = (
-            nn.Linear(self.embed, self.cfg.encoder_embed_dim) 
-            if self.embed != self.cfg.encoder_embed_dim 
-            else None
+            nn.Linear(self.embed, self.cfg.encoder_embed_dim) if self.embed != self.cfg.encoder_embed_dim else None
         )
 
         self.input_patch_size = self.cfg.input_patch_size
@@ -132,10 +127,8 @@ class BEATs(BaseBackbone):
         self.dropout_input = nn.Dropout(self.cfg.dropout_input)
 
         if self.cfg.deep_norm and self.cfg.layer_norm_first:
-            raise ValueError(
-                "deep_norm and layer_norm_first cannot both be True at the same time"
-            )
-            
+            raise ValueError("deep_norm and layer_norm_first cannot both be True at the same time")
+
         self.encoder = TransformerEncoder(self.cfg)
         self.layer_norm = LayerNorm(self.embed)
 
@@ -157,7 +150,7 @@ class BEATs(BaseBackbone):
             padding_mask (torch.Tensor): Input padding mask.
 
         Returns:
-            torch.Tensor: Adjusted padding mask, 
+            torch.Tensor: Adjusted padding mask,
                           True for valid tokens, False for padded positions.
         """
         extra = padding_mask.size(1) % features.size(1)

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/BEATs.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/BEATs.py
@@ -10,92 +10,138 @@
 import torch
 import torch.nn as nn
 import torchaudio.compliance.kaldi as ta_kaldi
+from torch.nn import LayerNorm
 
 from deepaudiox.modules.backbones.base_backbone import BaseBackbone
 from deepaudiox.modules.backbones.beats.beats_modules.backbone import (
     TransformerEncoder,
 )
-from torch.nn import LayerNorm
 
 
 class BEATsConfig:
+    """Configuration class for BEATs audio backbone.
+
+    Holds model hyperparameters, architecture settings, and preprocessing options.
+
+    Attributes:
+        input_patch_size (int): Patch size for patch embedding.
+        embed_dim (int): Dimension of patch embedding.
+        conv_bias (bool): Whether to include bias in convolutional encoder.
+        encoder_layers (int): Number of transformer encoder layers.
+        encoder_embed_dim (int): Transformer embedding dimension.
+        encoder_ffn_embed_dim (int): Transformer feed-forward dimension.
+        encoder_attention_heads (int): Number of attention heads in the transformer.
+        activation_fn (str): Activation function to use in the transformer.
+        layer_wise_gradient_decay_ratio (float): Decay ratio for layer-wise gradient decay.
+        layer_norm_first (bool): Whether to apply LayerNorm first in transformer.
+        deep_norm (bool): Whether to apply DeepNorm.
+        dropout (float): Transformer dropout probability.
+        attention_dropout (float): Dropout for attention weights.
+        activation_dropout (float): Dropout after activation in FFN.
+        encoder_layerdrop (float): Probability of dropping a transformer layer.
+        dropout_input (float): Dropout applied to input features.
+        conv_pos (int): Number of filters for convolutional positional embeddings.
+        conv_pos_groups (int): Number of groups for convolutional positional embedding.
+        relative_position_embedding (bool): Apply relative positional embeddings.
+        num_buckets (int): Number of buckets for relative positional embedding.
+        max_distance (int): Maximum distance for relative positional embedding.
+        gru_rel_pos (bool): Apply gated relative positional embedding.
+        finetuned_model (bool): Whether the model is fine-tuned.
+        predictor_dropout (float): Dropout probability for the predictor.
+        predictor_class (int): Number of target classes for predictor.
+    """
     def __init__(self, cfg=None):
-        self.input_patch_size: int = 16  # path size of patch embedding
-        self.embed_dim: int = 512  # patch embedding dimension
-        self.conv_bias: bool = False  # include bias in conv encoder
-
-        self.encoder_layers: int = 12  # num encoder layers in the transformer
-        self.encoder_embed_dim: int = 768  # encoder embedding dimension
-        self.encoder_ffn_embed_dim: int = 3072  # encoder embedding dimension for FFN
-        self.encoder_attention_heads: int = 12  # num encoder attention heads
-        self.activation_fn: str = "gelu"  # activation function to use
-
-        self.layer_wise_gradient_decay_ratio: float = 0.6  # ratio for layer-wise gradient decay
-        self.layer_norm_first: bool = False  # apply layernorm first in the transformer
-        self.deep_norm: bool = True  # apply deep_norm first in the transformer
-
-        # dropouts
-        self.dropout: float = 0.1  # dropout probability for the transformer
-        self.attention_dropout: float = 0.1  # dropout probability for attention weights
-        self.activation_dropout: float = 0.0  # dropout probability after activation in FFN
-        self.encoder_layerdrop: float = 0.05  # probability of dropping a tarnsformer layer
-        self.dropout_input: float = 0.0  # dropout to apply to the input (after feat extr)
-
-        # positional embeddings
-        self.conv_pos: int = 128  # number of filters for convolutional positional embeddings
-        self.conv_pos_groups: int = 16  # number of groups for convolutional positional embedding
-
-        # relative position embedding
-        self.relative_position_embedding: bool = True  # apply relative position embedding
-        self.num_buckets: int = 320  # number of buckets for relative position embedding
-        self.max_distance: int = 800  # maximum distance for relative position embedding
-        self.gru_rel_pos: bool = True  # apply gated relative position embedding
-
-        # label predictor
-        self.finetuned_model: bool = False  # whether the model is a fine-tuned model.
-        self.predictor_dropout: float = 0.1  # dropout probability for the predictor
-        self.predictor_class: int = 527  # target class number for the predictor
+        self.input_patch_size: int = 16
+        self.embed_dim: int = 512
+        self.conv_bias: bool = False
+        self.encoder_layers: int = 12
+        self.encoder_embed_dim: int = 768
+        self.encoder_ffn_embed_dim: int = 3072
+        self.encoder_attention_heads: int = 12
+        self.activation_fn: str = "gelu"
+        self.layer_wise_gradient_decay_ratio: float = 0.6
+        self.layer_norm_first: bool = False
+        self.deep_norm: bool = True
+        self.dropout: float = 0.1
+        self.attention_dropout: float = 0.1
+        self.activation_dropout: float = 0.0
+        self.encoder_layerdrop: float = 0.05
+        self.dropout_input: float = 0.0
+        self.conv_pos: int = 128
+        self.conv_pos_groups: int = 16
+        self.relative_position_embedding: bool = True
+        self.num_buckets: int = 320
+        self.max_distance: int = 800
+        self.gru_rel_pos: bool = True
+        self.finetuned_model: bool = False
+        self.predictor_dropout: float = 0.1
+        self.predictor_class: int = 527
 
         if cfg is not None:
             self.update(cfg)
 
     def update(self, cfg: dict):
+        """Update configuration with a dictionary of values.
+
+        Args:
+            cfg (dict): Dictionary containing configuration overrides.
+        """
         self.__dict__.update(cfg)
 
 
 class BEATs(BaseBackbone):
+    """BEATs audio backbone.
+
+    Implements the BEATs model for audio representation learning, including
+    patch embedding, transformer encoder, and optional classifier.
+
+    Args:
+        cfg (BEATsConfig | None): Configuration object for model parameters.
+            If None, a default BEATsConfig is used.
+        preprocess_flag (bool): Whether to perform preprocessing on input waveforms.
+        sample_rate (int): Sampling rate of input audio.
+    """
     def __init__(
         self, 
-        cfg: BEATsConfig = BEATsConfig(), 
+        cfg: BEATsConfig | None = None, 
         preprocess_flag: bool = True, 
         sample_rate: int = 16_000
     ) -> None:
         super().__init__(out_dim=768, sample_rate=sample_rate)
 
-        self.cfg = cfg
+        if cfg is None:
+            self.cfg = BEATsConfig()
+        else:
+            self.cfg = cfg
         self.preprocess_flag: bool = preprocess_flag
 
         self.fbank_mean, self.fbank_std = 15.41663, 6.55582
 
-        self.embed = cfg.embed_dim
+        self.embed = self.cfg.embed_dim
         self.post_extract_proj = (
-            nn.Linear(self.embed, cfg.encoder_embed_dim) if self.embed != cfg.encoder_embed_dim else None
+            nn.Linear(self.embed, self.cfg.encoder_embed_dim) 
+            if self.embed != self.cfg.encoder_embed_dim 
+            else None
         )
 
-        self.input_patch_size = cfg.input_patch_size
+        self.input_patch_size = self.cfg.input_patch_size
         self.patch_embedding = nn.Conv2d(
-            1, self.embed, kernel_size=self.input_patch_size, stride=self.input_patch_size, bias=cfg.conv_bias
+            1, self.embed, kernel_size=self.input_patch_size, stride=self.input_patch_size, bias=self.cfg.conv_bias
         )
 
-        self.dropout_input = nn.Dropout(cfg.dropout_input)
+        self.dropout_input = nn.Dropout(self.cfg.dropout_input)
 
-        assert not cfg.deep_norm or not cfg.layer_norm_first
-        self.encoder = TransformerEncoder(cfg)
+        if self.cfg.deep_norm and self.cfg.layer_norm_first:
+            raise ValueError(
+                "deep_norm and layer_norm_first cannot both be True at the same time"
+            )
+            
+        self.encoder = TransformerEncoder(self.cfg)
         self.layer_norm = LayerNorm(self.embed)
 
-        if cfg.finetuned_model:
-            self.predictor_dropout = nn.Dropout(cfg.predictor_dropout)
-            self.predictor = nn.Linear(cfg.encoder_embed_dim, cfg.predictor_class)
+        if self.cfg.finetuned_model:
+            self.predictor_dropout = nn.Dropout(self.cfg.predictor_dropout)
+            self.predictor = nn.Linear(self.cfg.encoder_embed_dim, self.cfg.predictor_class)
         else:
             self.predictor = None
 
@@ -104,6 +150,16 @@ class BEATs(BaseBackbone):
         features: torch.Tensor,
         padding_mask: torch.Tensor,
     ) -> torch.Tensor:
+        """Compute a padding mask aligned with feature sequence length.
+
+        Args:
+            features (torch.Tensor): Feature tensor.
+            padding_mask (torch.Tensor): Input padding mask.
+
+        Returns:
+            torch.Tensor: Adjusted padding mask, 
+                          True for valid tokens, False for padded positions.
+        """
         extra = padding_mask.size(1) % features.size(1)
         if extra > 0:
             padding_mask = padding_mask[:, :-extra]
@@ -112,6 +168,14 @@ class BEATs(BaseBackbone):
         return padding_mask
 
     def extract_features(self, waveforms: torch.Tensor) -> torch.Tensor:
+        """Convert raw waveforms to normalized log-Mel filterbank features.
+
+        Args:
+            waveforms (torch.Tensor): Input audio tensor.
+
+        Returns:
+            torch.Tensor: Filterbank features normalized by mean and std.
+        """
         fbanks = []
         for waveform in waveforms:
             waveform = waveform.unsqueeze(0) * 2**15
@@ -124,6 +188,15 @@ class BEATs(BaseBackbone):
         return fbank.unsqueeze(1)
 
     def forward(self, x: torch.Tensor, padding_mask: torch.Tensor | None = None):
+        """Forward pass through BEATs backbone.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            padding_mask (torch.Tensor | None): Optional padding mask.
+
+        Returns:
+            torch.Tensor: Output feature tensor after transformer encoding.
+        """
         if padding_mask is not None:
             padding_mask = self.forward_padding_mask(x, padding_mask)
 

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/backbone.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/backbone.py
@@ -53,6 +53,7 @@ class TransformerEncoder(nn.Module):
             - gru_rel_pos
             - encoder_layerdrop
     """
+
     def __init__(self, args):
         super().__init__()
 
@@ -229,6 +230,7 @@ class TransformerSentenceEncoderLayer(nn.Module):
         gru_rel_pos (bool): If True, uses GRU-based relative positional encoding.
         encoder_layers (int): Total number of encoder layers for DeepNorm.
     """
+
     def __init__(
         self,
         embedding_dim: float = 768,
@@ -428,7 +430,7 @@ class MultiheadAttention(nn.Module):
         self.head_dim = embed_dim // num_heads
         self.q_head_dim = self.head_dim
         self.k_head_dim = self.head_dim
-        
+
         if self.head_dim * num_heads != self.embed_dim:
             raise ValueError(f"embed_dim={self.embed_dim} must be divisible by num_heads={num_heads}")
 
@@ -438,9 +440,7 @@ class MultiheadAttention(nn.Module):
         self.encoder_decoder_attention = encoder_decoder_attention
 
         if self.self_attention and not self.qkv_same_dim:
-            raise ValueError(
-                "Self-attention requires query, key and value to be of the same size"
-            )
+            raise ValueError("Self-attention requires query, key and value to be of the same size")
 
         k_bias = True
         if rescale_init:
@@ -474,7 +474,7 @@ class MultiheadAttention(nn.Module):
         """
         Initialize parameters of the attention module.
 
-        Uses Xavier uniform initialization for linear layers. 
+        Uses Xavier uniform initialization for linear layers.
         If Q/K/V dimensions are the same, scaled initialization is applied.
         Relative positional embeddings, bias vectors, and output projections
         are initialized appropriately.
@@ -603,9 +603,7 @@ class MultiheadAttention(nn.Module):
         if embed_dim != self.embed_dim:
             raise ValueError(f"embed_dim={embed_dim} does not match self.embed_dim={self.embed_dim}")
         if list(query.size()) != [tgt_len, bsz, embed_dim]:
-            raise ValueError(
-                f"Expected query size {[tgt_len, bsz, embed_dim]}, but got {list(query.size())}"
-            )
+            raise ValueError(f"Expected query size {[tgt_len, bsz, embed_dim]}, but got {list(query.size())}")
         if key is not None:
             src_len, key_bsz, _ = key.size()
             if not torch.jit.is_scripting():
@@ -745,15 +743,11 @@ class MultiheadAttention(nn.Module):
 
         if key_padding_mask is not None:
             if key_padding_mask.size(0) != bsz:
-                raise ValueError(
-                    f"Expected key_padding_mask.size(0) to be {bsz}, "
-                    f"but got {key_padding_mask.size(0)}"
-                )
+                raise ValueError(f"Expected key_padding_mask.size(0) to be {bsz}, but got {key_padding_mask.size(0)}")
 
             if key_padding_mask.size(1) != src_len:
                 raise ValueError(
-                    f"Expected key_padding_mask.size(1) to be {src_len}, "
-                    f"but got {key_padding_mask.size(1)}"
+                    f"Expected key_padding_mask.size(1) to be {src_len}, but got {key_padding_mask.size(1)}"
                 )
 
         if self.add_zero_attn:
@@ -779,9 +773,7 @@ class MultiheadAttention(nn.Module):
 
         expected_shape = [bsz * self.num_heads, tgt_len, src_len]
         if list(attn_weights.size()) != expected_shape:
-            raise ValueError(
-                f"Expected attn_weights shape {expected_shape}, but got {list(attn_weights.size())}"
-            )
+            raise ValueError(f"Expected attn_weights shape {expected_shape}, but got {list(attn_weights.size())}")
 
         if attn_mask is not None:
             attn_mask = attn_mask.unsqueeze(0)
@@ -829,9 +821,7 @@ class MultiheadAttention(nn.Module):
         attn = torch.bmm(attn_probs, v)
         expected_shape = [bsz * self.num_heads, tgt_len, self.head_dim]
         if list(attn.size()) != expected_shape:
-            raise ValueError(
-                f"Expected attn shape {expected_shape}, but got {list(attn.size())}"
-            )
+            raise ValueError(f"Expected attn shape {expected_shape}, but got {list(attn.size())}")
         attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
         attn = self.out_proj(attn)
         attn_weights: Tensor | None = None

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/backbone.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/backbone.py
@@ -29,6 +29,30 @@ from deepaudiox.modules.backbones.beats.beats_modules.modules import (
 
 
 class TransformerEncoder(nn.Module):
+    """
+    Transformer Encoder module for BEATs.
+
+    Applies convolutional positional encoding followed by multiple
+    TransformerSentenceEncoderLayer layers.
+
+    Args:
+        args: Namespace or object containing model hyperparameters such as:
+            - encoder_embed_dim
+            - encoder_ffn_embed_dim
+            - encoder_attention_heads
+            - encoder_layers
+            - dropout
+            - attention_dropout
+            - activation_dropout
+            - activation_fn
+            - layer_norm_first
+            - deep_norm
+            - relative_position_embedding
+            - num_buckets
+            - max_distance
+            - gru_rel_pos
+            - encoder_layerdrop
+    """
     def __init__(self, args):
         super().__init__()
 
@@ -104,6 +128,20 @@ class TransformerEncoder(nn.Module):
         self.layer_wise_gradient_decay_ratio = getattr(args, "layer_wise_gradient_decay_ratio", 1)
 
     def forward(self, x, padding_mask=None, layer=None):
+        """
+        Forward pass through the encoder.
+
+        Args:
+            x (Tensor): Input tensor of shape (batch_size, seq_len, embed_dim).
+            padding_mask (Tensor, optional): Boolean mask of shape (batch_size, seq_len), where True
+                values indicate padding positions to ignore.
+            layer (int, optional): If specified, returns features at this specific layer.
+
+        Returns:
+            Tuple:
+                - Tensor: Output tensor of shape (batch_size, seq_len, embed_dim).
+                - List of tuples: Intermediate layer outputs as (x, pos_bias) for each layer.
+        """
         x, layer_results = self.extract_features(x, padding_mask, layer)
 
         if self.layer_norm_first and layer is None:
@@ -112,6 +150,19 @@ class TransformerEncoder(nn.Module):
         return x, layer_results
 
     def extract_features(self, x, padding_mask=None, tgt_layer=None):
+        """
+        Extract features from input through convolutional positional encoding and Transformer layers.
+
+        Args:
+            x (Tensor): Input tensor of shape (batch_size, seq_len, embed_dim).
+            padding_mask (Tensor, optional): Boolean mask for padding tokens.
+            tgt_layer (int, optional): If specified, stops computation at this layer.
+
+        Returns:
+            Tuple:
+                - Tensor: Output features of shape (batch_size, seq_len, embed_dim).
+                - List of tuples: Intermediate outputs (x, pos_bias) for each layer.
+        """
         if padding_mask is not None:
             x[padding_mask] = 0
 
@@ -155,6 +206,29 @@ class TransformerEncoder(nn.Module):
 
 
 class TransformerSentenceEncoderLayer(nn.Module):
+    """
+    Single Transformer encoder layer with optional GLU feedforward network.
+
+    Consists of multi-headed self-attention, optional relative positional bias,
+    feedforward network (FC + activation + FC), dropout, and layer normalization.
+
+    Args:
+        embedding_dim (int): Dimension of input embeddings.
+        ffn_embedding_dim (int): Hidden dimension of feedforward network.
+        num_attention_heads (int): Number of attention heads.
+        dropout (float): Dropout probability for attention output.
+        attention_dropout (float): Dropout probability within attention softmax.
+        activation_dropout (float): Dropout probability for feedforward activations.
+        activation_fn (str): Activation function for feedforward network. Options: "relu", "gelu", "tanh", "glu".
+        layer_norm_first (bool): If True, applies layer norm before self-attention.
+        deep_norm (bool): If True, applies DeepNorm scaling.
+        has_relative_attention_bias (bool): Whether to use relative positional bias.
+        num_buckets (int): Number of buckets for relative positional bias.
+        max_distance (int): Maximum relative distance for bias.
+        rescale_init (bool): If True, disables bias in Q/K linear layers.
+        gru_rel_pos (bool): If True, uses GRU-based relative positional encoding.
+        encoder_layers (int): Total number of encoder layers for DeepNorm.
+    """
     def __init__(
         self,
         embedding_dim: float = 768,
@@ -222,6 +296,22 @@ class TransformerSentenceEncoderLayer(nn.Module):
         need_weights: bool = False,
         pos_bias=None,
     ):
+        """
+        Forward pass through one Transformer encoder layer.
+
+        Args:
+            x (Tensor): Input tensor of shape (seq_len, batch_size, embed_dim).
+            self_attn_mask (Tensor, optional): Optional attention mask.
+            self_attn_padding_mask (Tensor, optional): Optional padding mask of shape (batch_size, seq_len).
+            need_weights (bool): If True, return attention weights.
+            pos_bias (Tensor, optional): Precomputed relative positional bias.
+
+        Returns:
+            Tuple:
+                - Tensor: Output tensor of same shape as input (seq_len, batch_size, embed_dim).
+                - Tensor | None: Attention weights (if `need_weights=True`), else None.
+                - Tensor | None: Position bias after attention computation.
+        """
         residual = x
 
         if self.layer_norm_first:
@@ -240,10 +330,7 @@ class TransformerSentenceEncoderLayer(nn.Module):
 
             residual = x
             x = self.final_layer_norm(x)
-            if self.activation_name == "glu":
-                x = self.fc1(x)
-            else:
-                x = self.activation_fn(self.fc1(x))
+            x = self.fc1(x) if self.activation_name == "glu" else self.activation_fn(self.fc1(x))
             x = self.dropout2(x)
             x = self.fc2(x)
             x = self.dropout3(x)
@@ -265,10 +352,7 @@ class TransformerSentenceEncoderLayer(nn.Module):
             x = self.self_attn_layer_norm(x)
 
             residual = x
-            if self.activation_name == "glu":
-                x = self.fc1(x)
-            else:
-                x = self.activation_fn(self.fc1(x))
+            x = self.fc1(x) if self.activation_name == "glu" else self.activation_fn(self.fc1(x))
             x = self.dropout2(x)
             x = self.fc2(x)
             x = self.dropout3(x)
@@ -279,9 +363,11 @@ class TransformerSentenceEncoderLayer(nn.Module):
 
 
 class MultiheadAttention(nn.Module):
-    """Multi-headed attention.
+    """
+    Multi-headed attention module with optional relative positional encoding and incremental state.
 
-    See "Attention Is All You Need" for more details.
+    Supports self-attention and encoder-decoder attention. Can integrate
+    relative positional bias and GRU-based relative position embeddings.
     """
 
     def __init__(
@@ -304,6 +390,26 @@ class MultiheadAttention(nn.Module):
         gru_rel_pos=False,
         rescale_init=False,
     ):
+        """
+        Args:
+            embed_dim (int): Dimension of input embeddings.
+            num_heads (int): Number of attention heads.
+            kdim (int, optional): Dimension of key embeddings. Defaults to embed_dim.
+            vdim (int, optional): Dimension of value embeddings. Defaults to embed_dim.
+            dropout (float): Dropout probability for attention output.
+            bias (bool): If True, add bias to linear projections.
+            add_bias_kv (bool): If True, adds learnable bias to key and value.
+            add_zero_attn (bool): If True, adds a zero attention vector.
+            self_attention (bool): Whether this is self-attention.
+            encoder_decoder_attention (bool): Whether this is encoder-decoder attention.
+            q_noise (float): Probability of quantization noise for linear projections.
+            qn_block_size (int): Block size for quantization noise.
+            has_relative_attention_bias (bool): If True, uses relative positional bias.
+            num_buckets (int): Number of buckets for relative positional bias.
+            max_distance (int): Maximum relative distance for bias.
+            gru_rel_pos (bool): If True, use GRU-based relative position encoding.
+            rescale_init (bool): If True, disables bias in Q/K linear layers.
+        """
         super().__init__()
         self.embed_dim = embed_dim
         self.kdim = kdim if kdim is not None else embed_dim
@@ -322,15 +428,19 @@ class MultiheadAttention(nn.Module):
         self.head_dim = embed_dim // num_heads
         self.q_head_dim = self.head_dim
         self.k_head_dim = self.head_dim
-        assert self.head_dim * num_heads == self.embed_dim, "embed_dim must be divisible by num_heads"
+        
+        if self.head_dim * num_heads != self.embed_dim:
+            raise ValueError(f"embed_dim={self.embed_dim} must be divisible by num_heads={num_heads}")
+
         self.scaling = self.head_dim**-0.5
 
         self.self_attention = self_attention
         self.encoder_decoder_attention = encoder_decoder_attention
 
-        assert not self.self_attention or self.qkv_same_dim, (
-            "Self-attention requires query, key and value to be of the same size"
-        )
+        if self.self_attention and not self.qkv_same_dim:
+            raise ValueError(
+                "Self-attention requires query, key and value to be of the same size"
+            )
 
         k_bias = True
         if rescale_init:
@@ -361,6 +471,14 @@ class MultiheadAttention(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
+        """
+        Initialize parameters of the attention module.
+
+        Uses Xavier uniform initialization for linear layers. 
+        If Q/K/V dimensions are the same, scaled initialization is applied.
+        Relative positional embeddings, bias vectors, and output projections
+        are initialized appropriately.
+        """
         if self.qkv_same_dim:
             # Empirically observed the convergence to be much better with
             # the scaled initialization
@@ -383,6 +501,16 @@ class MultiheadAttention(nn.Module):
             nn.init.xavier_normal_(self.relative_attention_bias.weight)
 
     def _relative_positions_bucket(self, relative_positions, bidirectional=True):
+        """
+        Convert relative positions to bucket indices for relative positional bias.
+
+        Args:
+            relative_positions (Tensor): Tensor of relative positions (key_pos - query_pos).
+            bidirectional (bool, optional): Whether attention is bidirectional. Defaults to True.
+
+        Returns:
+            Tensor: Bucket indices for each relative position, shape same as `relative_positions`.
+        """
         num_buckets = self.num_buckets
         max_distance = self.max_distance
         relative_buckets = 0
@@ -410,6 +538,16 @@ class MultiheadAttention(nn.Module):
         return relative_buckets
 
     def compute_bias(self, query_length, key_length):
+        """
+        Compute the relative positional bias tensor for attention.
+
+        Args:
+            query_length (int): Length of the query sequence.
+            key_length (int): Length of the key sequence.
+
+        Returns:
+            Tensor: Positional bias of shape (num_heads, query_length, key_length).
+        """
         context_position = torch.arange(query_length, dtype=torch.long)[:, None]
         memory_position = torch.arange(key_length, dtype=torch.long)[None, :]
         relative_position = memory_position - context_position
@@ -433,22 +571,27 @@ class MultiheadAttention(nn.Module):
         need_head_weights: bool = False,
         position_bias: Tensor | None = None,
     ) -> tuple[Tensor, Tensor | None, Tensor | None]:
-        """Input shape: Time x Batch x Channel
+        """
+        Compute multi-head attention.
 
         Args:
-            key_padding_mask (ByteTensor, optional): mask to exclude
-                keys that are pads, of shape `(batch, src_len)`, where
-                padding elements are indicated by 1s.
-            need_weights (bool, optional): return the attention weights,
-                averaged over heads (default: False).
-            attn_mask (ByteTensor, optional): typically used to
-                implement causal attention, where the mask prevents the
-                attention from looking forward in time (default: None).
-            before_softmax (bool, optional): return the raw attention
-                weights and values before the attention softmax.
-            need_head_weights (bool, optional): return the attention
-                weights for each head. Implies *need_weights*. Default:
-                return the average attention weights over all heads.
+            query (Tensor): Query tensor of shape (tgt_len, batch_size, embed_dim).
+            key (Tensor, optional): Key tensor of shape (src_len, batch_size, kdim). Defaults to None.
+            value (Tensor, optional): Value tensor of shape (src_len, batch_size, vdim). Defaults to None.
+            key_padding_mask (Tensor, optional): Mask for padding positions (batch, src_len). Defaults to None.
+            incremental_state (dict, optional): Cached state for incremental decoding. Defaults to None.
+            need_weights (bool, optional): Return attention weights averaged over heads. Defaults to True.
+            static_kv (bool, optional): Use static key/value for incremental decoding. Defaults to False.
+            attn_mask (Tensor, optional): Mask for causal attention (tgt_len, src_len). Defaults to None.
+            before_softmax (bool, optional): Return raw attention scores. Defaults to False.
+            need_head_weights (bool, optional): Return attention weights for each head. Defaults to False.
+            position_bias (Tensor, optional): Precomputed positional bias tensor. Defaults to None.
+
+        Returns:
+            Tuple[Tensor, Tensor | None, Tensor | None]:
+                - Attention output (tgt_len, batch_size, embed_dim)
+                - Attention weights (batch_size, tgt_len, src_len) if `need_weights=True`, else None
+                - Positional bias tensor used in attention
         """
         if need_head_weights:
             need_weights = True
@@ -457,14 +600,26 @@ class MultiheadAttention(nn.Module):
 
         tgt_len, bsz, embed_dim = query.size()
         src_len = tgt_len
-        assert embed_dim == self.embed_dim
-        assert list(query.size()) == [tgt_len, bsz, embed_dim]
+        if embed_dim != self.embed_dim:
+            raise ValueError(f"embed_dim={embed_dim} does not match self.embed_dim={self.embed_dim}")
+        if list(query.size()) != [tgt_len, bsz, embed_dim]:
+            raise ValueError(
+                f"Expected query size {[tgt_len, bsz, embed_dim]}, but got {list(query.size())}"
+            )
         if key is not None:
             src_len, key_bsz, _ = key.size()
             if not torch.jit.is_scripting():
-                assert key_bsz == bsz
-                assert value is not None
-                assert src_len, bsz == value.shape[:2]
+                if key_bsz != bsz:
+                    raise ValueError(f"key_bsz={key_bsz} does not match batch size bsz={bsz}")
+
+                if value is None:
+                    raise ValueError("Value tensor must not be None")
+
+                if (src_len, bsz) != tuple(value.shape[:2]):
+                    raise ValueError(
+                        f"Expected value shape first two dimensions to be ({src_len}, {bsz}), "
+                        f"but got {tuple(value.shape[:2])}"
+                    )
 
         if self.has_relative_attention_bias and position_bias is None:
             position_bias = self.compute_bias(tgt_len, src_len)
@@ -472,12 +627,14 @@ class MultiheadAttention(nn.Module):
 
         if incremental_state is not None:
             saved_state = self._get_input_buffer(incremental_state)
-            if saved_state is not None and "prev_key" in saved_state:
+            if saved_state is not None and "prev_key" in saved_state and static_kv:
                 # previous time steps are cached - no need to recompute
                 # key and value if they are static
-                if static_kv:
-                    assert self.encoder_decoder_attention and not self.self_attention
-                    key = value = None
+                if self.encoder_decoder_attention and self.self_attention:
+                    raise ValueError(
+                        "encoder_decoder_attention and self_attention cannot both be True at the same time"
+                    )
+                key = value = None
         else:
             saved_state = None
 
@@ -489,14 +646,16 @@ class MultiheadAttention(nn.Module):
             # encoder-decoder attention
             q = self.q_proj(query)
             if key is None:
-                assert value is None
+                if value is not None:
+                    raise ValueError("Expected value to be None")
                 k = v = None
             else:
                 k = self.k_proj(key)
                 v = self.v_proj(key)
 
         else:
-            assert key is not None and value is not None
+            if key is None or value is None:
+                raise ValueError("Both key and value tensors must not be None")
             q = self.q_proj(query)
             k = self.k_proj(key)
             v = self.v_proj(value)
@@ -505,7 +664,8 @@ class MultiheadAttention(nn.Module):
         q *= 1 / alpha
 
         if self.bias_k is not None:
-            assert self.bias_v is not None
+            if self.bias_v is None:
+                raise ValueError("bias_v must not be None")
             k = torch.cat([k, self.bias_k.repeat(1, bsz, 1)])
             v = torch.cat([v, self.bias_v.repeat(1, bsz, 1)])
             if attn_mask is not None:
@@ -529,27 +689,34 @@ class MultiheadAttention(nn.Module):
             # saved states are stored with shape (bsz, num_heads, seq_len, head_dim)
             if "prev_key" in saved_state:
                 _prev_key = saved_state["prev_key"]
-                assert _prev_key is not None
+                if _prev_key is None:
+                    raise ValueError("_prev_key must not be None")
+
                 prev_key = _prev_key.view(bsz * self.num_heads, -1, self.head_dim)
                 if static_kv:
                     k = prev_key
                 else:
-                    assert k is not None
+                    if k is None:
+                        raise ValueError("k must not be None")
                     k = torch.cat([prev_key, k], dim=1)
                 src_len = k.size(1)
             if "prev_value" in saved_state:
                 _prev_value = saved_state["prev_value"]
-                assert _prev_value is not None
+                if _prev_value is None:
+                    raise ValueError("_prev_value must not be None")
+
                 prev_value = _prev_value.view(bsz * self.num_heads, -1, self.head_dim)
                 if static_kv:
                     v = prev_value
                 else:
-                    assert v is not None
+                    if v is None:
+                        raise ValueError("v must not be None")
                     v = torch.cat([prev_value, v], dim=1)
             prev_key_padding_mask: Tensor | None = None
             if "prev_key_padding_mask" in saved_state:
                 prev_key_padding_mask = saved_state["prev_key_padding_mask"]
-            assert k is not None and v is not None
+            if k is None or v is None:
+                raise ValueError("Both k and v must not be None")
             key_padding_mask = MultiheadAttention._append_prev_key_padding_mask(
                 key_padding_mask=key_padding_mask,
                 prev_key_padding_mask=prev_key_padding_mask,
@@ -562,10 +729,14 @@ class MultiheadAttention(nn.Module):
             saved_state["prev_value"] = v.view(bsz, self.num_heads, -1, self.head_dim)
             saved_state["prev_key_padding_mask"] = key_padding_mask
             # In this branch incremental_state is never None
-            assert incremental_state is not None
+            if incremental_state is None:
+                raise ValueError("incremental_state must not be None")
             incremental_state = self._set_input_buffer(incremental_state, saved_state)
-        assert k is not None
-        assert k.size(1) == src_len
+        if k is None:
+            raise ValueError("k must not be None")
+
+        if k.size(1) != src_len:
+            raise ValueError(f"Expected k.size(1) to be {src_len}, but got {k.size(1)}")
 
         # This is part of a workaround to get around fork/join parallelism
         # not supporting Optional types.
@@ -573,11 +744,21 @@ class MultiheadAttention(nn.Module):
             key_padding_mask = None
 
         if key_padding_mask is not None:
-            assert key_padding_mask.size(0) == bsz
-            assert key_padding_mask.size(1) == src_len
+            if key_padding_mask.size(0) != bsz:
+                raise ValueError(
+                    f"Expected key_padding_mask.size(0) to be {bsz}, "
+                    f"but got {key_padding_mask.size(0)}"
+                )
+
+            if key_padding_mask.size(1) != src_len:
+                raise ValueError(
+                    f"Expected key_padding_mask.size(1) to be {src_len}, "
+                    f"but got {key_padding_mask.size(1)}"
+                )
 
         if self.add_zero_attn:
-            assert v is not None
+            if v is None:
+                raise ValueError("v must not be None")
             src_len += 1
             k = torch.cat([k, k.new_zeros((k.size(0), 1) + k.size()[2:])], dim=1)
             v = torch.cat([v, v.new_zeros((v.size(0), 1) + v.size()[2:])], dim=1)
@@ -596,7 +777,11 @@ class MultiheadAttention(nn.Module):
         attn_weights = (attn_weights - attn_weights.max(dim=-1, keepdim=True)[0]) * alpha
         attn_weights = self.apply_sparse_mask(attn_weights, tgt_len, src_len, bsz)
 
-        assert list(attn_weights.size()) == [bsz * self.num_heads, tgt_len, src_len]
+        expected_shape = [bsz * self.num_heads, tgt_len, src_len]
+        if list(attn_weights.size()) != expected_shape:
+            raise ValueError(
+                f"Expected attn_weights shape {expected_shape}, but got {list(attn_weights.size())}"
+            )
 
         if attn_mask is not None:
             attn_mask = attn_mask.unsqueeze(0)
@@ -638,9 +823,15 @@ class MultiheadAttention(nn.Module):
         attn_weights = attn_weights_float.type_as(attn_weights)
         attn_probs = self.dropout_module(attn_weights)
 
-        assert v is not None
+        if v is None:
+            raise ValueError("v must not be None")
+
         attn = torch.bmm(attn_probs, v)
-        assert list(attn.size()) == [bsz * self.num_heads, tgt_len, self.head_dim]
+        expected_shape = [bsz * self.num_heads, tgt_len, self.head_dim]
+        if list(attn.size()) != expected_shape:
+            raise ValueError(
+                f"Expected attn shape {expected_shape}, but got {list(attn.size())}"
+            )
         attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
         attn = self.out_proj(attn)
         attn_weights: Tensor | None = None
@@ -660,6 +851,19 @@ class MultiheadAttention(nn.Module):
         src_len: int,
         static_kv: bool,
     ) -> Tensor | None:
+        """
+        Combine current and previous key padding masks for incremental attention.
+
+        Args:
+            key_padding_mask (Tensor | None): Current key padding mask.
+            prev_key_padding_mask (Tensor | None): Previous key padding mask.
+            batch_size (int): Batch size.
+            src_len (int): Total sequence length of keys.
+            static_kv (bool): Whether keys are static (don't change during incremental decoding).
+
+        Returns:
+            Tensor | None: Combined key padding mask of shape (batch_size, src_len) or None.
+        """
         # saved key padding masks have shape (bsz, seq_len)
         if prev_key_padding_mask is not None and static_kv:
             new_key_padding_mask = prev_key_padding_mask
@@ -693,6 +897,15 @@ class MultiheadAttention(nn.Module):
     def _get_input_buffer(
         self, incremental_state: dict[str, dict[str, Tensor | None]] | None
     ) -> dict[str, Tensor | None]:
+        """
+        Retrieve the attention cache from incremental_state.
+
+        Args:
+            incremental_state (dict, optional): Dictionary holding cached states.
+
+        Returns:
+            dict: Cached attention state. Empty dict if no state exists.
+        """
         result = self.get_incremental_state(incremental_state, "attn_state")
         if result is not None:
             return result
@@ -705,29 +918,72 @@ class MultiheadAttention(nn.Module):
         incremental_state: dict[str, dict[str, Tensor | None]],
         buffer: dict[str, Tensor | None],
     ):
+        """
+        Store the attention cache into incremental_state.
+
+        Args:
+            incremental_state (dict): Dictionary holding cached states.
+            buffer (dict): Attention cache to store.
+
+        Returns:
+            dict: Updated incremental_state dictionary.
+        """
         return self.set_incremental_state(incremental_state, "attn_state", buffer)
 
     def apply_sparse_mask(self, attn_weights, tgt_len: int, src_len: int, bsz: int):
+        """
+        Placeholder for applying sparse attention masks. Currently a no-op.
+
+        Args:
+            attn_weights (Tensor): Attention weights before masking.
+            tgt_len (int): Length of target sequence.
+            src_len (int): Length of source sequence.
+            bsz (int): Batch size.
+
+        Returns:
+            Tensor: Potentially masked attention weights.
+        """
         return attn_weights
 
 
 def init_bert_params(module):
     """
-    Initialize the weights specific to the BERT Model.
-    This overrides the default initializations depending on the specified arguments.
-        1. If normal_init_linear_weights is set then weights of linear
-           layer will be initialized using the normal distribution and
-           bais will be set to the specified value.
-        2. If normal_init_embed_weights is set then weights of embedding
-           layer will be initialized using the normal distribution.
-        3. If normal_init_proj_weights is set then weights of
-           in_project_weight for MultiHeadAttention initialized using
-           the normal distribution (to be validated).
+    Initialize the parameters of BERT-related modules.
+
+    This function customizes the initialization of Linear, Embedding, and
+    MultiheadAttention layers for BERT-like models. It overrides PyTorch's
+    default initialization to follow standard BERT practices.
+
+    Behavior:
+        1. Linear layers: Weights are initialized from a normal distribution
+           (mean=0, std=0.02), and biases are set to zero.
+        2. Embedding layers: Weights are initialized from a normal distribution
+           (mean=0, std=0.02). If `padding_idx` is specified, the corresponding
+           embedding is zeroed.
+        3. MultiheadAttention layers: The `q_proj`, `k_proj`, and `v_proj`
+           linear projections are initialized from a normal distribution
+           (mean=0, std=0.02).
+
+    Args:
+        module (nn.Module): PyTorch module to initialize. Can be an instance of
+            nn.Linear, nn.Embedding, or MultiheadAttention.
+
+    Notes:
+        - This function is often used with `model.apply(init_bert_params)`
+          to recursively initialize all submodules of a model.
+        - The nested helper `normal_` ensures reproducibility on CPU and CUDA
+          by temporarily moving tensors to CPU for random initialization and
+          then restoring the original device.
     """
 
     def normal_(data):
-        # with FSDP, module params will be on CUDA, so we cast them back to CPU
-        # so that the RNG is consistent with and without FSDP
+        """
+        Initialize a tensor with values sampled from a normal distribution
+        (mean=0, std=0.02) while preserving device placement.
+
+        Args:
+            data (Tensor): Tensor to be initialized.
+        """
         data.copy_(data.cpu().normal_(mean=0.0, std=0.02).to(data.device))
 
     if isinstance(module, nn.Linear):

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/backbone.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/backbone.py
@@ -12,6 +12,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import math
+from typing import cast
 
 import numpy as np
 import torch
@@ -70,7 +71,8 @@ class TransformerEncoder(nn.Module):
         dropout = 0
         std = math.sqrt((4 * (1.0 - dropout)) / (args.conv_pos * self.embedding_dim))
         nn.init.normal_(self.pos_conv.weight, mean=0, std=std)
-        nn.init.constant_(self.pos_conv.bias, 0)
+        if self.pos_conv.bias is not None:
+            nn.init.constant_(self.pos_conv.bias, 0)
 
         self.pos_conv = nn.utils.weight_norm(self.pos_conv, name="weight", dim=2)
         self.pos_conv = nn.Sequential(self.pos_conv, SamePad(args.conv_pos), nn.GELU())
@@ -106,9 +108,11 @@ class TransformerEncoder(nn.Module):
             ]
         )
         if self.relative_position_embedding:
+            first_layer = cast(TransformerSentenceEncoderLayer, self.layers[0])
+            shared_bias = first_layer.self_attn.relative_attention_bias
             for i in range(1, args.encoder_layers):
-                del self.layers[i].self_attn.relative_attention_bias
-                self.layers[i].self_attn.relative_attention_bias = self.layers[0].self_attn.relative_attention_bias
+                layer = cast(TransformerSentenceEncoderLayer, self.layers[i])
+                layer.self_attn.relative_attention_bias = shared_bias
 
         self.layer_norm_first = args.layer_norm_first
         self.layer_norm = LayerNorm(self.embedding_dim)
@@ -119,12 +123,13 @@ class TransformerEncoder(nn.Module):
         if args.deep_norm:
             deep_norm_beta = math.pow(8 * args.encoder_layers, -1 / 4)
             for i in range(args.encoder_layers):
-                nn.init.xavier_normal_(self.layers[i].self_attn.k_proj.weight, gain=1)
-                nn.init.xavier_normal_(self.layers[i].self_attn.v_proj.weight, gain=deep_norm_beta)
-                nn.init.xavier_normal_(self.layers[i].self_attn.q_proj.weight, gain=1)
-                nn.init.xavier_normal_(self.layers[i].self_attn.out_proj.weight, gain=deep_norm_beta)
-                nn.init.xavier_normal_(self.layers[i].fc1.weight, gain=deep_norm_beta)
-                nn.init.xavier_normal_(self.layers[i].fc2.weight, gain=deep_norm_beta)
+                layer = cast(TransformerSentenceEncoderLayer, self.layers[i])
+                nn.init.xavier_normal_(cast(Tensor, layer.self_attn.k_proj.weight), gain=1)
+                nn.init.xavier_normal_(cast(Tensor, layer.self_attn.v_proj.weight), gain=deep_norm_beta)
+                nn.init.xavier_normal_(cast(Tensor, layer.self_attn.q_proj.weight), gain=1)
+                nn.init.xavier_normal_(cast(Tensor, layer.self_attn.out_proj.weight), gain=deep_norm_beta)
+                nn.init.xavier_normal_(cast(Tensor, layer.fc1.weight), gain=deep_norm_beta)
+                nn.init.xavier_normal_(cast(Tensor, layer.fc2.weight), gain=deep_norm_beta)
 
         self.layer_wise_gradient_decay_ratio = getattr(args, "layer_wise_gradient_decay_ratio", 1)
 
@@ -150,7 +155,12 @@ class TransformerEncoder(nn.Module):
 
         return x, layer_results
 
-    def extract_features(self, x, padding_mask=None, tgt_layer=None):
+    def extract_features(
+        self,
+        x: Tensor,
+        padding_mask: Tensor | None = None,
+        tgt_layer: int | None = None,
+    ) -> tuple[Tensor, list[tuple[Tensor, Tensor | None]]]:
         """
         Extract features from input through convolutional positional encoding and Transformer layers.
 
@@ -187,7 +197,7 @@ class TransformerEncoder(nn.Module):
         pos_bias = None
         for i, layer in enumerate(self.layers):
             if self.layer_wise_gradient_decay_ratio != 1.0:
-                x = GradMultiply.apply(x, self.layer_wise_gradient_decay_ratio)
+                x = cast(Tensor, GradMultiply.apply(x, self.layer_wise_gradient_decay_ratio))
             dropout_probability = np.random.random()
             if not self.training or (dropout_probability > self.layerdrop):
                 x, z, pos_bias = layer(x, self_attn_padding_mask=padding_mask, need_weights=False, pos_bias=pos_bias)
@@ -233,9 +243,9 @@ class TransformerSentenceEncoderLayer(nn.Module):
 
     def __init__(
         self,
-        embedding_dim: float = 768,
-        ffn_embedding_dim: float = 3072,
-        num_attention_heads: float = 8,
+        embedding_dim: int = 768,
+        ffn_embedding_dim: int = 3072,
+        num_attention_heads: int = 8,
         dropout: float = 0.1,
         attention_dropout: float = 0.1,
         activation_dropout: float = 0.1,
@@ -293,10 +303,10 @@ class TransformerSentenceEncoderLayer(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        self_attn_mask: torch.Tensor = None,
-        self_attn_padding_mask: torch.Tensor = None,
+        self_attn_mask: torch.Tensor | None = None,
+        self_attn_padding_mask: torch.Tensor | None = None,
         need_weights: bool = False,
-        pos_bias=None,
+        pos_bias: torch.Tensor | None = None,
     ):
         """
         Forward pass through one Transformer encoder layer.
@@ -422,6 +432,7 @@ class MultiheadAttention(nn.Module):
         self.dropout_module = nn.Dropout(dropout)
 
         self.has_relative_attention_bias = has_relative_attention_bias
+        self.relative_attention_bias: nn.Embedding | None = None
         self.num_buckets = num_buckets
         self.max_distance = max_distance
         if self.has_relative_attention_bias:
@@ -482,23 +493,24 @@ class MultiheadAttention(nn.Module):
         if self.qkv_same_dim:
             # Empirically observed the convergence to be much better with
             # the scaled initialization
-            nn.init.xavier_uniform_(self.k_proj.weight, gain=1 / math.sqrt(2))
-            nn.init.xavier_uniform_(self.v_proj.weight, gain=1 / math.sqrt(2))
-            nn.init.xavier_uniform_(self.q_proj.weight, gain=1 / math.sqrt(2))
+            nn.init.xavier_uniform_(cast(Tensor, self.k_proj.weight), gain=1 / math.sqrt(2))
+            nn.init.xavier_uniform_(cast(Tensor, self.v_proj.weight), gain=1 / math.sqrt(2))
+            nn.init.xavier_uniform_(cast(Tensor, self.q_proj.weight), gain=1 / math.sqrt(2))
         else:
-            nn.init.xavier_uniform_(self.k_proj.weight)
-            nn.init.xavier_uniform_(self.v_proj.weight)
-            nn.init.xavier_uniform_(self.q_proj.weight)
+            nn.init.xavier_uniform_(cast(Tensor, self.k_proj.weight))
+            nn.init.xavier_uniform_(cast(Tensor, self.v_proj.weight))
+            nn.init.xavier_uniform_(cast(Tensor, self.q_proj.weight))
 
-        nn.init.xavier_uniform_(self.out_proj.weight)
+        nn.init.xavier_uniform_(cast(Tensor, self.out_proj.weight))
         if self.out_proj.bias is not None:
-            nn.init.constant_(self.out_proj.bias, 0.0)
+            nn.init.constant_(cast(Tensor, self.out_proj.bias), 0.0)
         if self.bias_k is not None:
-            nn.init.xavier_normal_(self.bias_k)
+            nn.init.xavier_normal_(cast(Tensor, self.bias_k))
         if self.bias_v is not None:
-            nn.init.xavier_normal_(self.bias_v)
+            nn.init.xavier_normal_(cast(Tensor, self.bias_v))
         if self.has_relative_attention_bias:
-            nn.init.xavier_normal_(self.relative_attention_bias.weight)
+            rel_bias = cast(nn.Embedding, self.relative_attention_bias)
+            nn.init.xavier_normal_(rel_bias.weight)
 
     def _relative_positions_bucket(self, relative_positions, bidirectional=True):
         """
@@ -548,12 +560,15 @@ class MultiheadAttention(nn.Module):
         Returns:
             Tensor: Positional bias of shape (num_heads, query_length, key_length).
         """
+        if self.relative_attention_bias is None:
+            raise ValueError("relative_attention_bias must not be None")
         context_position = torch.arange(query_length, dtype=torch.long)[:, None]
         memory_position = torch.arange(key_length, dtype=torch.long)[None, :]
         relative_position = memory_position - context_position
         relative_position_bucket = self._relative_positions_bucket(relative_position, bidirectional=True)
-        relative_position_bucket = relative_position_bucket.to(self.relative_attention_bias.weight.device)
-        values = self.relative_attention_bias(relative_position_bucket)
+        rel_bias = cast(nn.Embedding, self.relative_attention_bias)
+        relative_position_bucket = relative_position_bucket.to(rel_bias.weight.device)
+        values = rel_bias(relative_position_bucket)
         values = values.permute([2, 0, 1])
         return values
 
@@ -606,7 +621,8 @@ class MultiheadAttention(nn.Module):
             raise ValueError(f"Expected query size {[tgt_len, bsz, embed_dim]}, but got {list(query.size())}")
         if key is not None:
             src_len, key_bsz, _ = key.size()
-            if not torch.jit.is_scripting():
+            is_scripting = getattr(torch.jit, "is_scripting", None)
+            if not (is_scripting() if callable(is_scripting) else False):
                 if key_bsz != bsz:
                     raise ValueError(f"key_bsz={key_bsz} does not match batch size bsz={bsz}")
 
@@ -621,6 +637,7 @@ class MultiheadAttention(nn.Module):
 
         if self.has_relative_attention_bias and position_bias is None:
             position_bias = self.compute_bias(tgt_len, src_len)
+            position_bias = cast(Tensor, position_bias)
             position_bias = position_bias.unsqueeze(0).repeat(bsz, 1, 1, 1).view(bsz * self.num_heads, tgt_len, src_len)
 
         if incremental_state is not None:
@@ -664,6 +681,10 @@ class MultiheadAttention(nn.Module):
         if self.bias_k is not None:
             if self.bias_v is None:
                 raise ValueError("bias_v must not be None")
+            if k is None or v is None:
+                raise ValueError("k and v must not be None when bias_k/bias_v are set")
+            k = cast(Tensor, k)
+            v = cast(Tensor, v)
             k = torch.cat([k, self.bias_k.repeat(1, bsz, 1)])
             v = torch.cat([v, self.bias_v.repeat(1, bsz, 1)])
             if attn_mask is not None:
@@ -732,6 +753,7 @@ class MultiheadAttention(nn.Module):
             incremental_state = self._set_input_buffer(incremental_state, saved_state)
         if k is None:
             raise ValueError("k must not be None")
+        k = cast(Tensor, k)
 
         if k.size(1) != src_len:
             raise ValueError(f"Expected k.size(1) to be {src_len}, but got {k.size(1)}")
@@ -919,6 +941,22 @@ class MultiheadAttention(nn.Module):
             dict: Updated incremental_state dictionary.
         """
         return self.set_incremental_state(incremental_state, "attn_state", buffer)
+
+    def get_incremental_state(
+        self, incremental_state: dict[str, dict[str, Tensor | None]] | None, key: str
+    ) -> dict[str, Tensor | None] | None:
+        if incremental_state is None:
+            return None
+        return incremental_state.get(key)
+
+    def set_incremental_state(
+        self,
+        incremental_state: dict[str, dict[str, Tensor | None]],
+        key: str,
+        value: dict[str, Tensor | None],
+    ) -> dict[str, dict[str, Tensor | None]]:
+        incremental_state[key] = value
+        return incremental_state
 
     def apply_sparse_mask(self, attn_weights, tgt_len: int, src_len: int, bsz: int):
         """

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/modules.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/modules.py
@@ -14,43 +14,104 @@ from torch import nn
 
 
 class GradMultiply(torch.autograd.Function):
+    """Gradient scaling operator.
+
+    Scales the gradient during the backward pass by a given factor while
+    leaving the forward pass unchanged. Useful for custom gradient manipulation.
+    """
     @staticmethod
     def forward(ctx, x, scale):
+        """Forward pass.
+
+        Args:
+            ctx: Context object to store information for backward computation.
+            x (torch.Tensor): Input tensor.
+            scale (float): Scaling factor for the gradient.
+
+        Returns:
+            torch.Tensor: Same as input tensor `x`.
+        """
         ctx.scale = scale
         res = x.new(x)
         return res
 
     @staticmethod
     def backward(ctx, grad):
+        """Backward pass: scales the gradient by `scale`.
+
+        Args:
+            ctx: Context object containing saved information.
+            grad (torch.Tensor): Gradient of the output.
+
+        Returns:
+            tuple: Scaled gradient for input `x` and `None` for `scale`.
+        """
         return grad * ctx.scale, None
 
 
 class SamePad(nn.Module):
-    def __init__(self, kernel_size, causal=False):
+    """Applies "same" padding to a sequence tensor.
+
+    Can be used for causal or non-causal padding in convolutional layers.
+    """
+    def __init__(self, kernel_size: int, causal: bool = False):
+        """
+        Args:
+            kernel_size (int): Kernel size of the convolution.
+            causal (bool): If True, apply causal padding (remove end positions).
+        """
         super().__init__()
         if causal:
             self.remove = kernel_size - 1
         else:
             self.remove = 1 if kernel_size % 2 == 0 else 0
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply padding adjustment.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (B, C, T).
+
+        Returns:
+            torch.Tensor: Tensor after removing extra positions for "same" padding.
+        """
         if self.remove > 0:
-            x = x[:, :, : -self.remove]
+            x = x[:, :, :-self.remove]
         return x
 
 
 class Swish(nn.Module):
+    """Swish activation function: x * sigmoid(x)."""
     def __init__(self):
-        super(Swish, self).__init__()
+        super().__init__()
         self.act = torch.nn.Sigmoid()
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply Swish activation.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Activated tensor.
+        """
         return x * self.act(x)
 
 
 class GLU_Linear(nn.Module):
-    def __init__(self, input_dim, output_dim, glu_type="sigmoid", bias_in_glu=True):
-        super(GLU_Linear, self).__init__()
+    """Linear layer with Gated Linear Unit (GLU) activation.
+
+    Supports different GLU types including sigmoid, swish, relu, and gelu.
+    """
+    def __init__(self, input_dim: int, output_dim: int, glu_type: str = "sigmoid", bias_in_glu: bool = True):
+        """
+        Args:
+            input_dim (int): Input feature dimension.
+            output_dim (int): Output feature dimension.
+            glu_type (str): Type of GLU activation. Options: "sigmoid", "swish", "relu", "gelu", "bilinear".
+            bias_in_glu (bool): Whether to include bias in linear layer.
+        """
+        super().__init__()
 
         self.glu_type = glu_type
         self.output_dim = output_dim
@@ -64,121 +125,140 @@ class GLU_Linear(nn.Module):
         elif glu_type == "gelu":
             self.glu_act = torch.nn.GELU()
 
-        if bias_in_glu:
-            self.linear = nn.Linear(input_dim, output_dim * 2, True)
-        else:
-            self.linear = nn.Linear(input_dim, output_dim * 2, False)
+        self.linear = nn.Linear(input_dim, output_dim * 2, bias_in_glu)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass through GLU linear layer.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (B, T, input_dim).
+
+        Returns:
+            torch.Tensor: Output tensor of shape (B, T, output_dim) after GLU activation.
+        """
         x = self.linear(x)
 
         if self.glu_type == "bilinear":
-            x = x[:, :, 0 : self.output_dim] * x[:, :, self.output_dim : self.output_dim * 2]
+            x = x[:, :, :self.output_dim] * x[:, :, self.output_dim: self.output_dim * 2]
         else:
-            x = x[:, :, 0 : self.output_dim] * self.glu_act(x[:, :, self.output_dim : self.output_dim * 2])
+            x = x[:, :, :self.output_dim] * self.glu_act(x[:, :, self.output_dim: self.output_dim * 2])
 
         return x
 
+
 def gelu(x: torch.Tensor) -> torch.Tensor:
+    """Gaussian Error Linear Unit (GELU) activation.
+
+    Args:
+        x (torch.Tensor): Input tensor.
+
+    Returns:
+        torch.Tensor: Activated tensor.
+    """
     return torch.nn.functional.gelu(x.float()).type_as(x)
 
 
 def get_activation_fn(activation: str):
-    """Returns the activation function corresponding to `activation`"""
+    """Get activation function by name.
 
+    Args:
+        activation (str): Name of the activation function. Options: "relu", "gelu", "tanh", "linear", "glu".
+
+    Raises:
+        RuntimeError: If the activation function is not supported.
+
+    Returns:
+        callable: Activation function.
+    """
     if activation == "relu":
         return F.relu
     elif activation == "gelu":
         return gelu
     elif activation == "tanh":
         return torch.tanh
-    elif activation == "linear" or activation == "glu":
+    elif activation in ["linear", "glu"]:
         return lambda x: x
     else:
         raise RuntimeError(f"--activation-fn {activation} not supported")
 
 
-def quant_noise(module, p, block_size):
-    """
-    Wraps modules and applies quantization noise to the weights for
-    subsequent quantization with Iterative Product Quantization as
-    described in "Training with Quantization Noise for Extreme Model Compression"
+def quant_noise(module: nn.Module, p: float, block_size: int) -> nn.Module:
+    """Apply Quantization Noise (QN) to Linear, Embedding, or Conv2d modules.
+
+    This simulates stochastic block-wise dropping of weights, useful for
+    training models with iterative product quantization (iPQ).
 
     Args:
-        - module: nn.Module
-        - p: amount of Quantization Noise
-        - block_size: size of the blocks for subsequent quantization with iPQ
+        module (nn.Module): Module to wrap (Linear, Embedding, or Conv2d).
+        p (float): Probability of dropping a block (0 disables QN).
+        block_size (int): Size of the blocks for quantization.
 
-    Remarks:
-        - Module weights must have the right sizes wrt the block size
-        - Only Linear, Embedding and Conv2d modules are supported for the moment
-        - For more detail on how to quantize by blocks with convolutional weights,
-          see "And the Bit Goes Down: Revisiting the Quantization of Neural Networks"
-        - We implement the simplest form of noise here as stated in the paper
-          which consists in randomly dropping blocks
+    Raises:
+        ValueError: If module type is unsupported or weight dimensions are incompatible with `block_size`.
+
+    Returns:
+        nn.Module: The same module with a forward pre-hook applied for quantization noise.
     """
-
-    # if no quantization noise, don't register hook
     if p <= 0:
         return module
 
-    # supported modules
-    assert isinstance(module, (nn.Linear, nn.Embedding, nn.Conv2d))
+    if not isinstance(module, (nn.Linear, nn.Embedding, nn.Conv2d)):
+        raise ValueError(
+            f"Expected module to be one of (nn.Linear, nn.Embedding, nn.Conv2d), "
+            f"but got {type(module)}"
+        )
 
-    # test whether module.weight has the right sizes wrt block_size
     is_conv = module.weight.ndim == 4
 
-    # 2D matrix
+    # Check input dimensions are compatible with block_size
     if not is_conv:
-        assert module.weight.size(1) % block_size == 0, "Input features must be a multiple of block sizes"
-
-    # 4D matrix
+        if module.weight.size(1) % block_size != 0:
+            raise ValueError(
+                f"Input features ({module.weight.size(1)}) must be a multiple of block size ({block_size})"
+            )
     else:
-        # 1x1 convolutions
         if module.kernel_size == (1, 1):
-            assert module.in_channels % block_size == 0, "Input channels must be a multiple of block sizes"
-        # regular convolutions
+            if module.in_channels % block_size != 0:
+                raise ValueError(
+                    f"Input channels ({module.in_channels}) must be a multiple of block size ({block_size})"
+                )
         else:
             k = module.kernel_size[0] * module.kernel_size[1]
-            assert k % block_size == 0, "Kernel size must be a multiple of block size"
+            if k % block_size != 0:
+                raise ValueError(f"Kernel size ({k}) must be a multiple of block size ({block_size})")
 
-    def _forward_pre_hook(mod, input):
-        # no noise for evaluation
-        if mod.training:
-            if not is_conv:
-                # gather weight and sizes
-                weight = mod.weight
-                in_features = weight.size(1)
-                out_features = weight.size(0)
+    def _forward_pre_hook(mod: nn.Module, input):
+        """Forward pre-hook to apply quantization noise to weights.
 
-                # split weight matrix into blocks and randomly drop selected blocks
-                mask = torch.zeros(in_features // block_size * out_features, device=weight.device)
+        Args:
+            mod (nn.Module): Module being executed.
+            input: Module input (unused here).
+        """
+        if not mod.training:
+            return
+
+        weight = mod.weight
+        if not is_conv:
+            in_features = weight.size(1)
+            out_features = weight.size(0)
+            mask = torch.zeros(in_features // block_size * out_features, device=weight.device)
+            mask.bernoulli_(p)
+            mask = mask.repeat_interleave(block_size, -1).view(-1, in_features)
+        else:
+            in_channels = mod.in_channels
+            out_channels = mod.out_channels
+            if mod.kernel_size == (1, 1):
+                mask = torch.zeros(int(in_channels // block_size * out_channels), device=weight.device)
                 mask.bernoulli_(p)
-                mask = mask.repeat_interleave(block_size, -1).view(-1, in_features)
-
+                mask = mask.repeat_interleave(block_size, -1).view(-1, in_channels)
             else:
-                # gather weight and sizes
-                weight = mod.weight
-                in_channels = mod.in_channels
-                out_channels = mod.out_channels
+                mask = torch.zeros(weight.size(0), weight.size(1), device=weight.device)
+                mask.bernoulli_(p)
+                mask = mask.unsqueeze(2).unsqueeze(3).repeat(1, 1, mod.kernel_size[0], mod.kernel_size[1])
 
-                # split weight matrix into blocks and randomly drop selected blocks
-                if mod.kernel_size == (1, 1):
-                    mask = torch.zeros(
-                        int(in_channels // block_size * out_channels),
-                        device=weight.device,
-                    )
-                    mask.bernoulli_(p)
-                    mask = mask.repeat_interleave(block_size, -1).view(-1, in_channels)
-                else:
-                    mask = torch.zeros(weight.size(0), weight.size(1), device=weight.device)
-                    mask.bernoulli_(p)
-                    mask = mask.unsqueeze(2).unsqueeze(3).repeat(1, 1, mod.kernel_size[0], mod.kernel_size[1])
-
-            # scale weights and apply mask
-            mask = mask.to(torch.bool)  # x.bool() is not currently supported in TorchScript
-            s = 1 / (1 - p)
-            mod.weight.data = s * weight.masked_fill(mask, 0)
+        mask = mask.to(torch.bool)
+        s = 1 / (1 - p)
+        mod.weight.data = s * weight.masked_fill(mask, 0)
 
     module.register_forward_pre_hook(_forward_pre_hook)
     return module

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/modules.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/modules.py
@@ -37,17 +37,18 @@ class GradMultiply(torch.autograd.Function):
         return res
 
     @staticmethod
-    def backward(ctx, grad):
+    def backward(ctx, *grad_outputs):
         """Backward pass: scales the gradient by `scale`.
 
         Args:
             ctx: Context object containing saved information.
-            grad (torch.Tensor): Gradient of the output.
+            grad_outputs (tuple[torch.Tensor]): Gradients of the outputs.
 
         Returns:
             tuple: Scaled gradient for input `x` and `None` for `scale`.
         """
-        return grad * ctx.scale, None
+        grad_output = grad_outputs[0]
+        return grad_output * ctx.scale, None
 
 
 class SamePad(nn.Module):
@@ -213,18 +214,29 @@ def quant_noise(module: nn.Module, p: float, block_size: int) -> nn.Module:
 
     # Check input dimensions are compatible with block_size
     if not is_conv:
-        if module.weight.size(1) % block_size != 0:
-            raise ValueError(
-                f"Input features ({module.weight.size(1)}) must be a multiple of block size ({block_size})"
-            )
-    else:
-        if module.kernel_size == (1, 1):
-            if module.in_channels % block_size != 0:
+        if isinstance(module, nn.Linear):
+            linear = module
+            if linear.weight.size(1) % block_size != 0:
                 raise ValueError(
-                    f"Input channels ({module.in_channels}) must be a multiple of block size ({block_size})"
+                    f"Input features ({linear.weight.size(1)}) must be a multiple of block size ({block_size})"
+                )
+        elif isinstance(module, nn.Embedding):
+            embed = module
+            if embed.weight.size(1) % block_size != 0:
+                raise ValueError(
+                    f"Input features ({embed.weight.size(1)}) must be a multiple of block size ({block_size})"
                 )
         else:
-            k = module.kernel_size[0] * module.kernel_size[1]
+            raise ValueError(f"Expected Linear or Embedding when not conv, got {type(module)}")
+    else:
+        conv = module
+        if not isinstance(conv, nn.Conv2d):
+            raise ValueError(f"Expected Conv2d when conv, got {type(module)}")
+        if conv.kernel_size == (1, 1):
+            if conv.in_channels % block_size != 0:
+                raise ValueError(f"Input channels ({conv.in_channels}) must be a multiple of block size ({block_size})")
+        else:
+            k = conv.kernel_size[0] * conv.kernel_size[1]
             if k % block_size != 0:
                 raise ValueError(f"Kernel size ({k}) must be a multiple of block size ({block_size})")
 
@@ -239,6 +251,8 @@ def quant_noise(module: nn.Module, p: float, block_size: int) -> nn.Module:
             return
 
         weight = mod.weight
+        if not isinstance(weight, torch.Tensor):
+            raise ValueError(f"Expected weight to be a Tensor, got {type(weight)}")
         if not is_conv:
             in_features = weight.size(1)
             out_features = weight.size(0)
@@ -246,16 +260,19 @@ def quant_noise(module: nn.Module, p: float, block_size: int) -> nn.Module:
             mask.bernoulli_(p)
             mask = mask.repeat_interleave(block_size, -1).view(-1, in_features)
         else:
-            in_channels = mod.in_channels
-            out_channels = mod.out_channels
-            if mod.kernel_size == (1, 1):
+            conv_mod = mod
+            if not isinstance(conv_mod, nn.Conv2d):
+                raise ValueError(f"Expected Conv2d module, got {type(mod)}")
+            in_channels = conv_mod.in_channels
+            out_channels = conv_mod.out_channels
+            if conv_mod.kernel_size == (1, 1):
                 mask = torch.zeros(int(in_channels // block_size * out_channels), device=weight.device)
                 mask.bernoulli_(p)
                 mask = mask.repeat_interleave(block_size, -1).view(-1, in_channels)
             else:
                 mask = torch.zeros(weight.size(0), weight.size(1), device=weight.device)
                 mask.bernoulli_(p)
-                mask = mask.unsqueeze(2).unsqueeze(3).repeat(1, 1, mod.kernel_size[0], mod.kernel_size[1])
+                mask = mask.unsqueeze(2).unsqueeze(3).repeat(1, 1, conv_mod.kernel_size[0], conv_mod.kernel_size[1])
 
         mask = mask.to(torch.bool)
         s = 1 / (1 - p)

--- a/src/deepaudiox/modules/backbones/beats/beats_modules/modules.py
+++ b/src/deepaudiox/modules/backbones/beats/beats_modules/modules.py
@@ -19,6 +19,7 @@ class GradMultiply(torch.autograd.Function):
     Scales the gradient during the backward pass by a given factor while
     leaving the forward pass unchanged. Useful for custom gradient manipulation.
     """
+
     @staticmethod
     def forward(ctx, x, scale):
         """Forward pass.
@@ -54,6 +55,7 @@ class SamePad(nn.Module):
 
     Can be used for causal or non-causal padding in convolutional layers.
     """
+
     def __init__(self, kernel_size: int, causal: bool = False):
         """
         Args:
@@ -76,12 +78,13 @@ class SamePad(nn.Module):
             torch.Tensor: Tensor after removing extra positions for "same" padding.
         """
         if self.remove > 0:
-            x = x[:, :, :-self.remove]
+            x = x[:, :, : -self.remove]
         return x
 
 
 class Swish(nn.Module):
     """Swish activation function: x * sigmoid(x)."""
+
     def __init__(self):
         super().__init__()
         self.act = torch.nn.Sigmoid()
@@ -103,6 +106,7 @@ class GLU_Linear(nn.Module):
 
     Supports different GLU types including sigmoid, swish, relu, and gelu.
     """
+
     def __init__(self, input_dim: int, output_dim: int, glu_type: str = "sigmoid", bias_in_glu: bool = True):
         """
         Args:
@@ -139,9 +143,9 @@ class GLU_Linear(nn.Module):
         x = self.linear(x)
 
         if self.glu_type == "bilinear":
-            x = x[:, :, :self.output_dim] * x[:, :, self.output_dim: self.output_dim * 2]
+            x = x[:, :, : self.output_dim] * x[:, :, self.output_dim : self.output_dim * 2]
         else:
-            x = x[:, :, :self.output_dim] * self.glu_act(x[:, :, self.output_dim: self.output_dim * 2])
+            x = x[:, :, : self.output_dim] * self.glu_act(x[:, :, self.output_dim : self.output_dim * 2])
 
         return x
 
@@ -203,10 +207,7 @@ def quant_noise(module: nn.Module, p: float, block_size: int) -> nn.Module:
         return module
 
     if not isinstance(module, (nn.Linear, nn.Embedding, nn.Conv2d)):
-        raise ValueError(
-            f"Expected module to be one of (nn.Linear, nn.Embedding, nn.Conv2d), "
-            f"but got {type(module)}"
-        )
+        raise ValueError(f"Expected module to be one of (nn.Linear, nn.Embedding, nn.Conv2d), but got {type(module)}")
 
     is_conv = module.weight.ndim == 4
 

--- a/src/deepaudiox/modules/backbones/passt/modules.py
+++ b/src/deepaudiox/modules/backbones/passt/modules.py
@@ -1,5 +1,4 @@
 import collections
-import warnings
 from itertools import repeat
 
 import torch
@@ -9,7 +8,18 @@ from deepaudiox.modules.backbones.passt.vit_helpers import DropPath
 
 
 class Mlp(nn.Module):
-    """ MLP as used in Vision Transformer, MLP-Mixer and related networks
+    """
+    Multilayer Perceptron (MLP) used in Vision Transformers.
+
+    Consists of two linear layers with an activation and dropout applied
+    between and after the layers.
+
+    Args:
+        in_features (int): Input feature dimension.
+        hidden_features (int, optional): Hidden layer dimension. Defaults to in_features.
+        out_features (int, optional): Output feature dimension. Defaults to in_features.
+        act_layer (nn.Module, optional): Activation function. Defaults to nn.GELU.
+        drop (float, optional): Dropout probability. Defaults to 0.
     """
     def __init__(
         self, 
@@ -28,6 +38,15 @@ class Mlp(nn.Module):
         self.drop = nn.Dropout(drop)
 
     def forward(self, x):
+        """
+        Forward pass through the MLP.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (batch, seq_len, in_features).
+
+        Returns:
+            torch.Tensor: Output tensor of shape (batch, seq_len, out_features).
+        """
         x = self.fc1(x)
         x = self.act(x)
         x = self.drop(x)
@@ -36,7 +55,20 @@ class Mlp(nn.Module):
         return x
 
 class PatchEmbed(nn.Module):
-    """ 2D Image to Patch Embedding
+    """
+    2D Patch Embedding layer for spectrogram or image input.
+
+    Converts an input image/spectrogram into non-overlapping or strided patches,
+    then projects each patch to a given embedding dimension.
+
+    Args:
+        img_size (int | tuple): Input image size (height, width).
+        patch_size (int | tuple): Size of each patch.
+        stride (int | tuple): Stride for patch extraction. Defaults to patch_size.
+        in_chans (int): Number of input channels. Defaults to 3.
+        embed_dim (int): Dimension of the output embeddings.
+        norm_layer (nn.Module, optional): Optional normalization layer. Defaults to None.
+        flatten (bool): If True, flattens patches into sequence (B, N, C). Defaults to True.
     """
     def __init__(
         self, 
@@ -65,6 +97,15 @@ class PatchEmbed(nn.Module):
 
     # From PyTorch internals
     def _ntuple(self, n):
+        """
+        Converts input into a tuple of length n.
+
+        Args:
+            n (int): Length of tuple.
+
+        Returns:
+            Callable: Function that converts input into tuple of length n.
+        """
         def parse(x):
             if isinstance(x, collections.abc.Iterable) and not isinstance(x, str):
                 return tuple(x)
@@ -72,13 +113,17 @@ class PatchEmbed(nn.Module):
         return parse
 
     def forward(self, x):
+        """
+        Forward pass to convert input image/spectrogram to patch embeddings.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (B, C, H, W).
+
+        Returns:
+            torch.Tensor: Patch embeddings of shape (B, N, embed_dim) if flatten=True,
+                          else (B, embed_dim, H_patch, W_patch).
+        """
         B, C, H, W = x.shape
-        if not (self.img_size[0] == H and self.img_size[1] == W):
-            warnings.warn(
-                f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]}).",
-                stacklevel=2
-            )
-        # to do maybe replace weights
         x = self.proj(x)
         if self.flatten:
             x = x.flatten(2).transpose(1, 2)  # BCHW -> BNC
@@ -86,6 +131,16 @@ class PatchEmbed(nn.Module):
         return x
 
 class Attention(nn.Module):
+    """
+    Multi-Head Self-Attention module.
+
+    Args:
+        dim (int): Input embedding dimension.
+        num_heads (int): Number of attention heads. Defaults to 8.
+        qkv_bias (bool): If True, include bias in Q/K/V projections. Defaults to False.
+        attn_drop (float): Dropout probability on attention weights. Defaults to 0.
+        proj_drop (float): Dropout probability on output projection. Defaults to 0.
+    """
     def __init__(
         self, 
         dim: int, 
@@ -106,6 +161,15 @@ class Attention(nn.Module):
         self.plus1_trick = False
         
     def forward(self, x):
+        """
+        Forward pass for multi-head attention.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (B, N, C).
+
+        Returns:
+            torch.Tensor: Output tensor of shape (B, N, C).
+        """
         B, N, C = x.shape
         qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
         q, k, v = qkv[0], qkv[1], qkv[2]  # make torchscript happy (cannot use tensor as tuple)
@@ -126,6 +190,23 @@ class Attention(nn.Module):
         return x
 
 class Block(nn.Module):
+    """
+    Transformer encoder block.
+
+    Consists of LayerNorm -> Multi-Head Attention -> Add & Norm -> MLP -> Add & Norm,
+    with optional stochastic depth (DropPath).
+
+    Args:
+        dim (int): Input embedding dimension.
+        num_heads (int): Number of attention heads.
+        mlp_ratio (float): Hidden dimension ratio for MLP. Defaults to 4.0.
+        qkv_bias (bool): If True, include bias in Q/K/V projections. Defaults to False.
+        drop (float): Dropout probability. Defaults to 0.
+        attn_drop (float): Dropout probability for attention. Defaults to 0.
+        drop_path (float): Stochastic depth rate. Defaults to 0.
+        act_layer (nn.Module): Activation function for MLP. Defaults to nn.GELU.
+        norm_layer (nn.Module): Normalization layer. Defaults to nn.LayerNorm.
+    """
     def __init__(
         self, 
         dim: int, 
@@ -148,6 +229,15 @@ class Block(nn.Module):
         self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
 
     def forward(self, x):
+        """
+        Forward pass through the transformer block.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (B, N, C).
+
+        Returns:
+            torch.Tensor: Output tensor of same shape as input.
+        """
         x = x + self.drop_path(self.attn(self.norm1(x)))
         x = x + self.drop_path(self.mlp(self.norm2(x)))
         return x

--- a/src/deepaudiox/modules/backbones/passt/modules.py
+++ b/src/deepaudiox/modules/backbones/passt/modules.py
@@ -1,5 +1,4 @@
-import collections
-from itertools import repeat
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn
@@ -22,7 +21,14 @@ class Mlp(nn.Module):
         drop (float, optional): Dropout probability. Defaults to 0.
     """
 
-    def __init__(self, in_features: int, hidden_features=None, out_features=None, act_layer=nn.GELU, drop: float = 0.0):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features=None,
+        out_features=None,
+        act_layer: Callable[..., nn.Module] = nn.GELU,
+        drop: float = 0.0,
+    ):
         super().__init__()
         out_features = out_features or in_features
         hidden_features = hidden_features or in_features
@@ -68,19 +74,18 @@ class PatchEmbed(nn.Module):
 
     def __init__(
         self,
-        img_size: int = 224,
-        patch_size: int = 16,
-        stride: int = 16,
+        img_size: int | tuple[int, int] = 224,
+        patch_size: int | tuple[int, int] = 16,
+        stride: int | tuple[int, int] = 16,
         in_chans: int = 3,
         embed_dim: int = 768,
         norm_layer: nn.Module | None = None,
         flatten: bool = True,
     ):
         super().__init__()
-        to_2tuple = self._ntuple(2)
-        img_size = to_2tuple(img_size)
-        patch_size = to_2tuple(patch_size)
-        stride = to_2tuple(stride)
+        img_size = self._to_2tuple(img_size)
+        patch_size = self._to_2tuple(patch_size)
+        stride = self._to_2tuple(stride)
         self.img_size = img_size
         self.patch_size = patch_size
         self.stride = stride
@@ -92,23 +97,19 @@ class PatchEmbed(nn.Module):
         self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
 
     # From PyTorch internals
-    def _ntuple(self, n):
+    def _to_2tuple(self, x: int | tuple[int, int]) -> tuple[int, int]:
         """
-        Converts input into a tuple of length n.
+        Converts input into a tuple of length 2.
 
         Args:
-            n (int): Length of tuple.
+            x (int | tuple[int, int]): Input size.
 
         Returns:
-            Callable: Function that converts input into tuple of length n.
+            tuple[int, int]: Normalized 2-tuple.
         """
-
-        def parse(x):
-            if isinstance(x, collections.abc.Iterable) and not isinstance(x, str):
-                return tuple(x)
-            return tuple(repeat(x, n))
-
-        return parse
+        if isinstance(x, tuple):
+            return x
+        return (x, x)
 
     def forward(self, x):
         """
@@ -213,8 +214,8 @@ class Block(nn.Module):
         drop: float = 0.0,
         attn_drop: float = 0.0,
         drop_path: float = 0.0,
-        act_layer: nn.Module = nn.GELU,
-        norm_layer: nn.Module = nn.LayerNorm,
+        act_layer: Callable[..., nn.Module] = nn.GELU,
+        norm_layer: Callable[[int], nn.Module] = nn.LayerNorm,
     ):
         super().__init__()
         self.norm1 = norm_layer(dim)

--- a/src/deepaudiox/modules/backbones/passt/modules.py
+++ b/src/deepaudiox/modules/backbones/passt/modules.py
@@ -1,0 +1,153 @@
+import collections
+import warnings
+from itertools import repeat
+
+import torch
+import torch.nn as nn
+
+from deepaudiox.modules.backbones.passt.vit_helpers import DropPath
+
+
+class Mlp(nn.Module):
+    """ MLP as used in Vision Transformer, MLP-Mixer and related networks
+    """
+    def __init__(
+        self, 
+        in_features: int, 
+        hidden_features = None, 
+        out_features = None, 
+        act_layer  =nn.GELU, 
+        drop: float = 0.
+    ):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+class PatchEmbed(nn.Module):
+    """ 2D Image to Patch Embedding
+    """
+    def __init__(
+        self, 
+        img_size: int = 224, 
+        patch_size: int = 16, 
+        stride: int =16, 
+        in_chans: int = 3, 
+        embed_dim: int = 768, 
+        norm_layer: nn.Module | None = None,
+        flatten: bool = True
+    ):
+        super().__init__()
+        to_2tuple =  self._ntuple(2)
+        img_size = to_2tuple(img_size)
+        patch_size = to_2tuple(patch_size)
+        stride = to_2tuple(stride)
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.stride = stride
+        self.grid_size = (img_size[0] // stride[0], img_size[1] // stride[1])
+        self.num_patches = self.grid_size[0] * self.grid_size[1]
+        self.flatten = flatten
+        self.embed_dim = embed_dim
+        self.proj = nn.Conv2d(in_chans, embed_dim, kernel_size=patch_size, stride=stride)
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    # From PyTorch internals
+    def _ntuple(self, n):
+        def parse(x):
+            if isinstance(x, collections.abc.Iterable) and not isinstance(x, str):
+                return tuple(x)
+            return tuple(repeat(x, n))
+        return parse
+
+    def forward(self, x):
+        B, C, H, W = x.shape
+        if not (self.img_size[0] == H and self.img_size[1] == W):
+            warnings.warn(
+                f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]}).",
+                stacklevel=2
+            )
+        # to do maybe replace weights
+        x = self.proj(x)
+        if self.flatten:
+            x = x.flatten(2).transpose(1, 2)  # BCHW -> BNC
+        x = self.norm(x)
+        return x
+
+class Attention(nn.Module):
+    def __init__(
+        self, 
+        dim: int, 
+        num_heads: int = 8, 
+        qkv_bias: bool = False, 
+        attn_drop: float = 0., 
+        proj_drop: float = 0.
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = head_dim ** -0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.plus1_trick = False
+        
+    def forward(self, x):
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
+        q, k, v = qkv[0], qkv[1], qkv[2]  # make torchscript happy (cannot use tensor as tuple)
+
+        attn = (q @ k.transpose(-2, -1)) * self.scale
+        if self.plus1_trick:
+            # +1 trick
+            attn = torch.cat([attn, torch.zeros(attn.shape[:-1]+(1,), dtype=attn.dtype, device=attn.device)], dim=-1)
+        attn = attn.softmax(dim=-1)
+        if self.plus1_trick:
+            # +1 trick
+            attn = attn[...,:-1]
+        attn = self.attn_drop(attn)
+
+        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(
+        self, 
+        dim: int, 
+        num_heads: int, 
+        mlp_ratio: float = 4., 
+        qkv_bias: bool =False, 
+        drop: float = 0., 
+        attn_drop: float = 0.,
+        drop_path: float = 0., 
+        act_layer: nn.Module = nn.GELU, 
+        norm_layer: nn.Module = nn.LayerNorm
+    ):
+        super().__init__()
+        self.norm1 = norm_layer(dim)
+        self.attn = Attention(dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop)
+        # NOTE: drop path for stochastic depth, we shall see if this is better than dropout here
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+        self.norm2 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
+
+    def forward(self, x):
+        x = x + self.drop_path(self.attn(self.norm1(x)))
+        x = x + self.drop_path(self.mlp(self.norm2(x)))
+        return x

--- a/src/deepaudiox/modules/backbones/passt/modules.py
+++ b/src/deepaudiox/modules/backbones/passt/modules.py
@@ -21,14 +21,8 @@ class Mlp(nn.Module):
         act_layer (nn.Module, optional): Activation function. Defaults to nn.GELU.
         drop (float, optional): Dropout probability. Defaults to 0.
     """
-    def __init__(
-        self, 
-        in_features: int, 
-        hidden_features = None, 
-        out_features = None, 
-        act_layer  =nn.GELU, 
-        drop: float = 0.
-    ):
+
+    def __init__(self, in_features: int, hidden_features=None, out_features=None, act_layer=nn.GELU, drop: float = 0.0):
         super().__init__()
         out_features = out_features or in_features
         hidden_features = hidden_features or in_features
@@ -54,6 +48,7 @@ class Mlp(nn.Module):
         x = self.drop(x)
         return x
 
+
 class PatchEmbed(nn.Module):
     """
     2D Patch Embedding layer for spectrogram or image input.
@@ -70,18 +65,19 @@ class PatchEmbed(nn.Module):
         norm_layer (nn.Module, optional): Optional normalization layer. Defaults to None.
         flatten (bool): If True, flattens patches into sequence (B, N, C). Defaults to True.
     """
+
     def __init__(
-        self, 
-        img_size: int = 224, 
-        patch_size: int = 16, 
-        stride: int =16, 
-        in_chans: int = 3, 
-        embed_dim: int = 768, 
+        self,
+        img_size: int = 224,
+        patch_size: int = 16,
+        stride: int = 16,
+        in_chans: int = 3,
+        embed_dim: int = 768,
         norm_layer: nn.Module | None = None,
-        flatten: bool = True
+        flatten: bool = True,
     ):
         super().__init__()
-        to_2tuple =  self._ntuple(2)
+        to_2tuple = self._ntuple(2)
         img_size = to_2tuple(img_size)
         patch_size = to_2tuple(patch_size)
         stride = to_2tuple(stride)
@@ -106,10 +102,12 @@ class PatchEmbed(nn.Module):
         Returns:
             Callable: Function that converts input into tuple of length n.
         """
+
         def parse(x):
             if isinstance(x, collections.abc.Iterable) and not isinstance(x, str):
                 return tuple(x)
             return tuple(repeat(x, n))
+
         return parse
 
     def forward(self, x):
@@ -130,6 +128,7 @@ class PatchEmbed(nn.Module):
         x = self.norm(x)
         return x
 
+
 class Attention(nn.Module):
     """
     Multi-Head Self-Attention module.
@@ -141,25 +140,21 @@ class Attention(nn.Module):
         attn_drop (float): Dropout probability on attention weights. Defaults to 0.
         proj_drop (float): Dropout probability on output projection. Defaults to 0.
     """
+
     def __init__(
-        self, 
-        dim: int, 
-        num_heads: int = 8, 
-        qkv_bias: bool = False, 
-        attn_drop: float = 0., 
-        proj_drop: float = 0.
+        self, dim: int, num_heads: int = 8, qkv_bias: bool = False, attn_drop: float = 0.0, proj_drop: float = 0.0
     ):
         super().__init__()
         self.num_heads = num_heads
         head_dim = dim // num_heads
-        self.scale = head_dim ** -0.5
+        self.scale = head_dim**-0.5
 
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
         self.attn_drop = nn.Dropout(attn_drop)
         self.proj = nn.Linear(dim, dim)
         self.proj_drop = nn.Dropout(proj_drop)
         self.plus1_trick = False
-        
+
     def forward(self, x):
         """
         Forward pass for multi-head attention.
@@ -177,17 +172,18 @@ class Attention(nn.Module):
         attn = (q @ k.transpose(-2, -1)) * self.scale
         if self.plus1_trick:
             # +1 trick
-            attn = torch.cat([attn, torch.zeros(attn.shape[:-1]+(1,), dtype=attn.dtype, device=attn.device)], dim=-1)
+            attn = torch.cat([attn, torch.zeros(attn.shape[:-1] + (1,), dtype=attn.dtype, device=attn.device)], dim=-1)
         attn = attn.softmax(dim=-1)
         if self.plus1_trick:
             # +1 trick
-            attn = attn[...,:-1]
+            attn = attn[..., :-1]
         attn = self.attn_drop(attn)
 
         x = (attn @ v).transpose(1, 2).reshape(B, N, C)
         x = self.proj(x)
         x = self.proj_drop(x)
         return x
+
 
 class Block(nn.Module):
     """
@@ -207,23 +203,24 @@ class Block(nn.Module):
         act_layer (nn.Module): Activation function for MLP. Defaults to nn.GELU.
         norm_layer (nn.Module): Normalization layer. Defaults to nn.LayerNorm.
     """
+
     def __init__(
-        self, 
-        dim: int, 
-        num_heads: int, 
-        mlp_ratio: float = 4., 
-        qkv_bias: bool =False, 
-        drop: float = 0., 
-        attn_drop: float = 0.,
-        drop_path: float = 0., 
-        act_layer: nn.Module = nn.GELU, 
-        norm_layer: nn.Module = nn.LayerNorm
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        qkv_bias: bool = False,
+        drop: float = 0.0,
+        attn_drop: float = 0.0,
+        drop_path: float = 0.0,
+        act_layer: nn.Module = nn.GELU,
+        norm_layer: nn.Module = nn.LayerNorm,
     ):
         super().__init__()
         self.norm1 = norm_layer(dim)
         self.attn = Attention(dim, num_heads=num_heads, qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop)
         # NOTE: drop path for stochastic depth, we shall see if this is better than dropout here
-        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
         self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)

--- a/src/deepaudiox/modules/backbones/passt/passt.py
+++ b/src/deepaudiox/modules/backbones/passt/passt.py
@@ -146,7 +146,7 @@ class PaSST(BaseBackbone):
             self.cfg = PaSSTConfig()
         else:
             self.cfg = cfg
-        self.feature_extractor = AugmentMelSTFT()
+        self.feature_extractor = AugmentMelSTFT(sr=sample_rate)
 
         self.num_classes = self.cfg.num_classes
         self.u_patchout = self.cfg.u_patchout
@@ -228,7 +228,7 @@ class PaSST(BaseBackbone):
         features = features.unsqueeze(1)
         return features
 
-    def forward(self, features: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, padding_mask: torch.Tensor | None = None) -> torch.Tensor:
         """
         Forward pass of the PaSST backbone.
 
@@ -240,50 +240,50 @@ class PaSST(BaseBackbone):
                           transformer blocks, and normalization. Returns features excluding
                           class/distillation tokens.
         """
-        features = self.patch_embed(features)
-        B_dim, E_dim, F_dim, T_dim = features.shape
+        x = self.patch_embed(x)
+        B_dim, E_dim, F_dim, T_dim = x.shape
         time_new_pos_embed = self.time_new_pos_embed
-        if features.shape[-1] != time_new_pos_embed.shape[-1]:
-            time_new_pos_embed = time_new_pos_embed[:, :, :, : features.shape[-1]]
-        features = features + time_new_pos_embed
-        features = features + self.freq_new_pos_embed
+        if x.shape[-1] != time_new_pos_embed.shape[-1]:
+            time_new_pos_embed = time_new_pos_embed[:, :, :, : x.shape[-1]]
+        x = x + time_new_pos_embed
+        x = x + self.freq_new_pos_embed
 
         if self.training and self.s_patchout_t:
             # ([1, 768, 1, 82])
             random_indices = torch.randperm(T_dim)[: T_dim - self.s_patchout_t].sort().values
-            features = features[:, :, :, random_indices]
+            x = x[:, :, :, random_indices]
         if self.training and self.s_patchout_f:
             # [1, 768, 12, 1]
             random_indices = torch.randperm(F_dim)[: F_dim - self.s_patchout_f].sort().values
-            features = features[:, :, random_indices, :]
+            x = x[:, :, random_indices, :]
 
         # Flatten the sequence
-        features = features.flatten(2).transpose(1, 2)
+        x = x.flatten(2).transpose(1, 2)
         if self.training and self.u_patchout:
-            seq_len = features.shape[1]
+            seq_len = x.shape[1]
             random_indices = torch.randperm(seq_len)[: seq_len - self.u_patchout].sort().values
-            features = features[:, random_indices, :]
+            x = x[:, random_indices, :]
 
         cls_tokens = self.cls_token.expand(B_dim, -1, -1) + self.new_pos_embed[:, :1, :]
         if self.dist_token is None:
-            features = torch.cat((cls_tokens, features), dim=1)
+            x = torch.cat((cls_tokens, x), dim=1)
         else:
             dist_token = self.dist_token.expand(B_dim, -1, -1) + self.new_pos_embed[:, 1:, :]
-            features = torch.cat((cls_tokens, dist_token, features), dim=1)
+            x = torch.cat((cls_tokens, dist_token, x), dim=1)
 
-        features = self.pos_drop(features)
-        features = self.blocks(features)
+        x = self.pos_drop(x)
+        x = self.blocks(x)
 
-        features = self.norm(features)
+        x = self.norm(x)
 
         # if self.dist_token is None:
         #     return self.pre_logits(features[:, 0])
         # else:
         #     return features[:, 0], features[:, 1]
         if self.dist_token is None:
-            return self.pre_logits(features[:, 1:])
+            return self.pre_logits(x[:, 1:])
         else:
-            return self.pre_logits(features[:, 2:])
+            return self.pre_logits(x[:, 2:])
 
 
 def adapt_image_pos_embed_to_passt(posemb, num_tokens=1, gs_new=(), mode="bicubic"):

--- a/src/deepaudiox/modules/backbones/passt/passt.py
+++ b/src/deepaudiox/modules/backbones/passt/passt.py
@@ -1,0 +1,337 @@
+"""
+Most of this code comes from the timm  library.
+We tried to disentangle from the timm library version.
+
+Adapted from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
+
+"""
+import logging
+import math
+import warnings
+from collections import OrderedDict
+from functools import partial
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from deepaudiox.modules.backbones.base_backbone import BaseBackbone
+from deepaudiox.modules.backbones.passt.modules import Block, PatchEmbed
+from deepaudiox.modules.backbones.passt.preprocess import AugmentMelSTFT
+from deepaudiox.modules.backbones.passt.vit_helpers import (
+    init_vit_weights,
+    load_pretrained_weights,
+    trunc_normal_,
+)
+
+# Global variables
+_logger = logging.getLogger()
+
+class PaSSTConfig:
+    def __init__(self, cfg=None):
+        self.url = 'https://github.com/kkoutini/PaSST/releases/download/v.0.0.9/passt-s-kd-ap.486.pt'
+        self.num_classes = 527, 
+        self.pool_size = None
+        self.crop_pct = 1.0
+        self.interpolation = 'bicubic'
+        self.fixed_input_size = True
+        self.mean = (0.485, 0.456, 0.406)
+        self.std = (0.229, 0.224, 0.225)
+        self.first_conv = 'patch_embed.proj' 
+        self.classifiers = ('head.1', 'head_dist')
+        self.u_patchout = 0
+        self.s_patchout_t = 0
+        self.s_patchout_f = 0
+        self.embed_dim = 768
+        self.distilled = True
+        self.pretrained = True
+        self.img_size = (128, 998)
+        self.patch_size = 16
+        self.fstride = 10
+        self.tstride = 10
+        self.in_chans = 1
+        self.depth = 12
+        self.num_heads = 12
+        self.mlp_ratio = 4.
+        self.qkv_bias = True
+        self.representation_size = None
+        self.drop_rate = 0.
+        self.attn_drop_rate = 0.
+        self.drop_path_rate = 0.
+        self.norm_layer = None
+        self.act_layer = None
+        self.weight_init = ''
+
+        if cfg is not None:
+            self.update(cfg)
+
+    def update(self, cfg: dict):
+        self.__dict__.update(cfg)
+
+class PaSST(BaseBackbone):
+    def __init__(
+        self, 
+        cfg: PaSSTConfig = PaSSTConfig(),
+        sample_rate: int = 16_000
+    ):
+        super().__init__(out_dim=768, sample_rate=sample_rate)
+        self.cfg = cfg
+        self.feature_extractor = AugmentMelSTFT()
+
+        self.num_classes = self.cfg.num_classes
+        self.u_patchout = self.cfg.u_patchout
+        self.s_patchout_t = self.cfg.s_patchout_t
+        self.s_patchout_f = self.cfg.s_patchout_f
+        self.num_features = self.embed_dim = self.cfg.embed_dim 
+        self.num_tokens = 2 if self.cfg.distilled else 1
+        self.embed_dim = self.cfg.embed_dim
+        self.classifiers = self.cfg.classifiers
+        self.patch_embed = PatchEmbed(
+            img_size=self.cfg.img_size, 
+            patch_size=self.cfg.patch_size, 
+            stride=(self.cfg.fstride, self.cfg.tstride), 
+            in_chans=self.cfg.in_chans, 
+            embed_dim=self.embed_dim,
+            flatten=False
+        )
+
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, self.embed_dim))
+        self.dist_token = nn.Parameter(torch.zeros(1, 1, self.embed_dim)) if self.cfg.distilled else None
+
+        self.new_pos_embed = nn.Parameter(torch.zeros(1, self.num_tokens, self.embed_dim))  # for C and D tokens
+        self.freq_new_pos_embed = nn.Parameter(torch.zeros(1, self.embed_dim, self.patch_embed.grid_size[0], 1))  # | f
+        self.time_new_pos_embed = nn.Parameter(torch.zeros(1, self.embed_dim, 1, self.patch_embed.grid_size[1]))  # __ t
+        self.pos_drop = nn.Dropout(p=self.cfg.drop_rate)
+
+        norm_layer = self.cfg.norm_layer or partial(nn.LayerNorm, eps=1e-6)
+        dpr = [x.item() for x in torch.linspace(0, self.cfg.drop_path_rate, self.cfg.depth)]
+        self.blocks = nn.Sequential(*[
+            Block(
+                dim=self.embed_dim, 
+                num_heads=self.cfg.num_heads, 
+                mlp_ratio=self.cfg.mlp_ratio, 
+                qkv_bias=self.cfg.qkv_bias, 
+                drop=self.cfg.drop_rate,
+                attn_drop=self.cfg.attn_drop_rate, 
+                drop_path=dpr[i], 
+                norm_layer=norm_layer, 
+                act_layer=self.cfg.act_layer or nn.GELU
+            )
+            for i in range(self.cfg.depth)])
+        self.norm = norm_layer(self.embed_dim)
+
+        # Representation layer
+        if self.cfg.representation_size and not self.distilled:
+            self.num_features = self.cfg.representation_size
+            self.pre_logits = nn.Sequential(
+                OrderedDict([
+                    ('fc', nn.Linear(self.embed_dim, self.cfg.representation_size)),
+                    ('act', nn.Tanh())
+                ])
+            )
+        else:
+            self.pre_logits = nn.Identity()        
+        
+        # Initialize weights
+        if self.cfg.weight_init not in ['nlhb', '']:
+            raise ValueError(f"Unsuported weight initialization mode: {self.cfg.weight_init}")
+
+        trunc_normal_(self.new_pos_embed, std=.02)
+        trunc_normal_(self.freq_new_pos_embed, std=.02)
+        trunc_normal_(self.time_new_pos_embed, std=.02)
+        if self.dist_token is not None:
+            trunc_normal_(self.dist_token, std=.02)
+        trunc_normal_(self.cls_token, std=.02)
+        self.apply(init_vit_weights)
+
+        # Load pre-trained weights
+        if self.cfg.url is not None:
+            load_pretrained_weights(
+                model = self,
+                pretrained_url = self.cfg.url,
+                num_classes = self.num_classes,
+                in_chans = self.cfg.in_chans,
+                filter_fn = checkpoint_filter_fn,
+                strict = True,
+                first_conv = self.cfg.first_conv,
+                classifiers = self.classifiers
+            )
+
+    def extract_features(self, waveforms: torch.Tensor) -> torch.Tensor:
+        features = self.feature_extractor(waveforms)
+        features = features.unsqueeze(1)
+        return features
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        features = self.patch_embed(features)
+        B_dim, E_dim, F_dim, T_dim = features.shape 
+        time_new_pos_embed = self.time_new_pos_embed
+        if features.shape[-1] != time_new_pos_embed.shape[-1]:
+            time_new_pos_embed = time_new_pos_embed[:, :, :, :features.shape[-1]]    
+        features = features + time_new_pos_embed
+        features = features + self.freq_new_pos_embed
+
+        if self.training and self.s_patchout_t:
+            # ([1, 768, 1, 82])
+            random_indices = torch.randperm(T_dim)[:T_dim - self.s_patchout_t].sort().values
+            features = features[:, :, :, random_indices]
+        if self.training and self.s_patchout_f:
+            # [1, 768, 12, 1]
+            random_indices = torch.randperm(F_dim)[:F_dim - self.s_patchout_f].sort().values
+            features = features[:, :, random_indices, :]
+
+        # Flatten the sequence
+        features = features.flatten(2).transpose(1, 2)
+        if self.training and self.u_patchout:
+            seq_len = features.shape[1]
+            random_indices = torch.randperm(seq_len)[:seq_len - self.u_patchout].sort().values
+            features = features[:, random_indices, :]
+
+        cls_tokens = self.cls_token.expand(B_dim, -1, -1) + self.new_pos_embed[:, :1, :]
+        if self.dist_token is None:
+            features = torch.cat((cls_tokens, features), dim=1)
+        else:
+            dist_token = self.dist_token.expand(B_dim, -1, -1) + self.new_pos_embed[:, 1:, :]
+            features = torch.cat((cls_tokens, dist_token, features), dim=1)
+
+        features = self.pos_drop(features)
+        features = self.blocks(features)
+
+        features = self.norm(features)
+
+        # if self.dist_token is None:
+        #     return self.pre_logits(features[:, 0])
+        # else:
+        #     return features[:, 0], features[:, 1]
+        if self.dist_token is None:
+            return self.pre_logits(features)
+        else:
+            return features
+
+def adapt_image_pos_embed_to_passt(
+    posemb, 
+    num_tokens=1, 
+    gs_new=(), 
+    mode='bicubic'
+):
+    # Rescale the grid of position embeddings when loading from state_dict. Adapted from
+    # https://github.com/google-research/vision_transformer/blob/00883dd691c63a6830751563748663526e811cee/vit_jax/checkpoint.py#L224
+    _logger.info('Resized position embedding: %s to %s with %s cls/dis tokens', posemb.shape, gs_new, num_tokens)
+    
+    if num_tokens:
+        posemb_tok, posemb_grid = posemb[:, :num_tokens], posemb[0, num_tokens:]
+    else:
+        posemb_tok, posemb_grid = posemb[:, :0], posemb[0]
+        
+    gs_old = int(math.sqrt(len(posemb_grid)))
+
+    assert len(gs_new) >= 2
+
+    _logger.info('Position embedding grid-size from %s to %s', [gs_old, gs_old], gs_new)
+
+    posemb_grid = posemb_grid.reshape(1, gs_old, gs_old, -1).permute(0, 3, 1, 2)
+    posemb_grid = F.interpolate(posemb_grid, size=gs_new, mode=mode, align_corners=False)
+    freq_new_pos_embed = posemb_grid.mean(dim=3, keepdim=True)
+    time_new_pos_embed = posemb_grid.mean(dim=2, keepdim=True)
+
+    _logger.info('New Position cls/dstl embedding %s', posemb_tok.shape)
+    _logger.info('New FREQ Position embedding %s', freq_new_pos_embed.shape)
+    _logger.info('New TIME Position embedding %s', time_new_pos_embed.shape)
+    
+    return posemb_tok, freq_new_pos_embed, time_new_pos_embed
+
+def resize_pos_embed(
+    posemb, 
+    posemb_new, 
+    num_tokens=1, 
+    gs_new=(), 
+    mode='bicubic'
+):
+    # Rescale the grid of position embeddings when loading from state_dict. Adapted from
+    # https://github.com/google-research/vision_transformer/blob/00883dd691c63a6830751563748663526e811cee/vit_jax/checkpoint.py#L224
+    _logger.info('Resized position embedding: %s to %s with %s cls/dis tokens', posemb.shape, posemb_new.shape, num_tokens)
+    ntok_new = posemb_new.shape[1]
+    if num_tokens:
+        posemb_tok, posemb_grid = posemb[:, :num_tokens], posemb[0, num_tokens:]
+        ntok_new -= num_tokens
+    else:
+        posemb_tok, posemb_grid = posemb[:, :0], posemb[0]
+    gs_old = int(math.sqrt(len(posemb_grid)))
+    if not len(gs_new):  # backwards compatibility
+        gs_new = [int(math.sqrt(ntok_new))] * 2
+    assert len(gs_new) >= 2
+    _logger.info('Position embedding grid-size from %s to %s', [gs_old, gs_old], gs_new)
+    posemb_grid = posemb_grid.reshape(1, gs_old, gs_old, -1).permute(0, 3, 1, 2)
+    posemb_grid = F.interpolate(posemb_grid, size=gs_new, mode=mode, align_corners=False)
+    posemb_grid = posemb_grid.permute(0, 2, 3, 1).reshape(1, gs_new[0] * gs_new[1], -1)
+    posemb = torch.cat([posemb_tok, posemb_grid], dim=1)
+    return posemb
+
+def checkpoint_filter_fn(state_dict, model):
+    """
+    Convert patch embedding weights from manual patchify + linear projection
+    to convolution-based patch embedding and adapt positional embeddings.
+    """
+    out_dict = {}
+
+    # Handle checkpoints saved as {"model": state_dict}
+    if "model" in state_dict:
+        state_dict = state_dict["model"]
+
+    state_dict = {k: v for k, v in state_dict.items()}
+
+    # --------------------------------------------------
+    # Adapt ImageNet positional embeddings to PaSST
+    # --------------------------------------------------
+    if "time_new_pos_embed" not in state_dict:
+        _logger.info(
+            "Adapting pos embedding from ImageNet pretrained model to PaSST."
+        )
+
+        pos_embed = state_dict.pop("pos_embed")
+        (
+            new_pos_embed,
+            freq_new_pos_embed,
+            time_new_pos_embed,
+        ) = adapt_image_pos_embed_to_passt(
+            pos_embed,
+            getattr(model, "num_tokens", 1),
+            model.patch_embed.grid_size,
+        )
+
+        state_dict["new_pos_embed"] = new_pos_embed
+        state_dict["freq_new_pos_embed"] = freq_new_pos_embed
+        state_dict["time_new_pos_embed"] = time_new_pos_embed
+
+    # --------------------------------------------------
+    # Process remaining parameters
+    # --------------------------------------------------
+    for key, value in state_dict.items():
+        if "patch_embed.proj.weight" in key and value.ndim < 4:
+            # Old models: linear patch embedding → conv patch embedding
+            (
+                out_channels,
+                in_channels,
+                kernel_height,
+                kernel_width,
+            ) = model.patch_embed.proj.weight.shape
+
+            value = value.reshape(
+                out_channels,
+                -1,
+                kernel_height,
+                kernel_width,
+            )
+
+        elif key == "pos_embed" and value.shape != model.new_pos_embed.shape:
+            # Defensive resize (should rarely occur)
+            value = resize_pos_embed(
+                value,
+                model.new_pos_embed,
+                getattr(model, "num_tokens", 1),
+                model.patch_embed.grid_size,
+            )
+
+        out_dict[key] = value
+
+    return out_dict

--- a/src/deepaudiox/modules/backbones/passt/passt.py
+++ b/src/deepaudiox/modules/backbones/passt/passt.py
@@ -5,6 +5,7 @@ We tried to disentangle from the timm library version.
 Adapted from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
 
 """
+
 import math
 from collections import OrderedDict
 from functools import partial
@@ -59,15 +60,15 @@ class PaSSTConfig:
     """
 
     def __init__(self, cfg=None):
-        self.num_classes = 527, 
+        self.num_classes = (527,)
         self.pool_size = None
         self.crop_pct = 1.0
-        self.interpolation = 'bicubic'
+        self.interpolation = "bicubic"
         self.fixed_input_size = True
         self.mean = (0.485, 0.456, 0.406)
         self.std = (0.229, 0.224, 0.225)
-        self.first_conv = 'patch_embed.proj' 
-        self.classifiers = ('head.1', 'head_dist')
+        self.first_conv = "patch_embed.proj"
+        self.classifiers = ("head.1", "head_dist")
         self.u_patchout = 0
         self.s_patchout_t = 0
         self.s_patchout_f = 0
@@ -81,15 +82,15 @@ class PaSSTConfig:
         self.in_chans = 1
         self.depth = 12
         self.num_heads = 12
-        self.mlp_ratio = 4.
+        self.mlp_ratio = 4.0
         self.qkv_bias = True
         self.representation_size = None
-        self.drop_rate = 0.
-        self.attn_drop_rate = 0.
-        self.drop_path_rate = 0.
+        self.drop_rate = 0.0
+        self.attn_drop_rate = 0.0
+        self.drop_path_rate = 0.0
         self.norm_layer = None
         self.act_layer = None
-        self.weight_init = ''
+        self.weight_init = ""
 
         if cfg is not None:
             self.update(cfg)
@@ -102,6 +103,7 @@ class PaSSTConfig:
             cfg (dict): Dictionary containing configuration keys and values to update.
         """
         self.__dict__.update(cfg)
+
 
 class PaSST(BaseBackbone):
     """
@@ -128,7 +130,7 @@ class PaSST(BaseBackbone):
         norm (nn.Module): Layer normalization applied to final features.
         pre_logits (nn.Module): Optional representation layer before classifier.
     """
-    
+
     def __init__(self, cfg: PaSSTConfig | None = None, sample_rate: int = 16_000):
         """_summary_
 
@@ -150,17 +152,17 @@ class PaSST(BaseBackbone):
         self.u_patchout = self.cfg.u_patchout
         self.s_patchout_t = self.cfg.s_patchout_t
         self.s_patchout_f = self.cfg.s_patchout_f
-        self.num_features = self.embed_dim = self.cfg.embed_dim 
+        self.num_features = self.embed_dim = self.cfg.embed_dim
         self.num_tokens = 2 if self.cfg.distilled else 1
         self.embed_dim = self.cfg.embed_dim
         self.classifiers = self.cfg.classifiers
         self.patch_embed = PatchEmbed(
-            img_size=self.cfg.img_size, 
-            patch_size=self.cfg.patch_size, 
-            stride=(self.cfg.fstride, self.cfg.tstride), 
-            in_chans=self.cfg.in_chans, 
+            img_size=self.cfg.img_size,
+            patch_size=self.cfg.patch_size,
+            stride=(self.cfg.fstride, self.cfg.tstride),
+            in_chans=self.cfg.in_chans,
             embed_dim=self.embed_dim,
-            flatten=False
+            flatten=False,
         )
 
         self.cls_token = nn.Parameter(torch.zeros(1, 1, self.embed_dim))
@@ -173,43 +175,43 @@ class PaSST(BaseBackbone):
 
         norm_layer = self.cfg.norm_layer or partial(nn.LayerNorm, eps=1e-6)
         dpr = [x.item() for x in torch.linspace(0, self.cfg.drop_path_rate, self.cfg.depth)]
-        self.blocks = nn.Sequential(*[
-            Block(
-                dim=self.embed_dim, 
-                num_heads=self.cfg.num_heads, 
-                mlp_ratio=self.cfg.mlp_ratio, 
-                qkv_bias=self.cfg.qkv_bias, 
-                drop=self.cfg.drop_rate,
-                attn_drop=self.cfg.attn_drop_rate, 
-                drop_path=dpr[i], 
-                norm_layer=norm_layer, 
-                act_layer=self.cfg.act_layer or nn.GELU
-            )
-            for i in range(self.cfg.depth)])
+        self.blocks = nn.Sequential(
+            *[
+                Block(
+                    dim=self.embed_dim,
+                    num_heads=self.cfg.num_heads,
+                    mlp_ratio=self.cfg.mlp_ratio,
+                    qkv_bias=self.cfg.qkv_bias,
+                    drop=self.cfg.drop_rate,
+                    attn_drop=self.cfg.attn_drop_rate,
+                    drop_path=dpr[i],
+                    norm_layer=norm_layer,
+                    act_layer=self.cfg.act_layer or nn.GELU,
+                )
+                for i in range(self.cfg.depth)
+            ]
+        )
         self.norm = norm_layer(self.embed_dim)
 
         # Representation layer
         if self.cfg.representation_size and not self.distilled:
             self.num_features = self.cfg.representation_size
             self.pre_logits = nn.Sequential(
-                OrderedDict([
-                    ('fc', nn.Linear(self.embed_dim, self.cfg.representation_size)),
-                    ('act', nn.Tanh())
-                ])
+                OrderedDict([("fc", nn.Linear(self.embed_dim, self.cfg.representation_size)), ("act", nn.Tanh())])
             )
         else:
-            self.pre_logits = nn.Identity()        
-        
+            self.pre_logits = nn.Identity()
+
         # Initialize weights
-        if self.cfg.weight_init not in ['nlhb', '']:
+        if self.cfg.weight_init not in ["nlhb", ""]:
             raise ValueError(f"Unsuported weight initialization mode: {self.cfg.weight_init}")
 
-        trunc_normal_(self.new_pos_embed, std=.02)
-        trunc_normal_(self.freq_new_pos_embed, std=.02)
-        trunc_normal_(self.time_new_pos_embed, std=.02)
+        trunc_normal_(self.new_pos_embed, std=0.02)
+        trunc_normal_(self.freq_new_pos_embed, std=0.02)
+        trunc_normal_(self.time_new_pos_embed, std=0.02)
         if self.dist_token is not None:
-            trunc_normal_(self.dist_token, std=.02)
-        trunc_normal_(self.cls_token, std=.02)
+            trunc_normal_(self.dist_token, std=0.02)
+        trunc_normal_(self.cls_token, std=0.02)
         self.apply(init_vit_weights)
 
     def extract_features(self, waveforms: torch.Tensor) -> torch.Tensor:
@@ -234,32 +236,32 @@ class PaSST(BaseBackbone):
             features (torch.Tensor): Input spectrogram features (batch, channels, freq, time).
 
         Returns:
-            torch.Tensor: Transformer features after patch embedding, positional encoding, 
+            torch.Tensor: Transformer features after patch embedding, positional encoding,
                           transformer blocks, and normalization. Returns features excluding
                           class/distillation tokens.
         """
         features = self.patch_embed(features)
-        B_dim, E_dim, F_dim, T_dim = features.shape 
+        B_dim, E_dim, F_dim, T_dim = features.shape
         time_new_pos_embed = self.time_new_pos_embed
         if features.shape[-1] != time_new_pos_embed.shape[-1]:
-            time_new_pos_embed = time_new_pos_embed[:, :, :, :features.shape[-1]]    
+            time_new_pos_embed = time_new_pos_embed[:, :, :, : features.shape[-1]]
         features = features + time_new_pos_embed
         features = features + self.freq_new_pos_embed
 
         if self.training and self.s_patchout_t:
             # ([1, 768, 1, 82])
-            random_indices = torch.randperm(T_dim)[:T_dim - self.s_patchout_t].sort().values
+            random_indices = torch.randperm(T_dim)[: T_dim - self.s_patchout_t].sort().values
             features = features[:, :, :, random_indices]
         if self.training and self.s_patchout_f:
             # [1, 768, 12, 1]
-            random_indices = torch.randperm(F_dim)[:F_dim - self.s_patchout_f].sort().values
+            random_indices = torch.randperm(F_dim)[: F_dim - self.s_patchout_f].sort().values
             features = features[:, :, random_indices, :]
 
         # Flatten the sequence
         features = features.flatten(2).transpose(1, 2)
         if self.training and self.u_patchout:
             seq_len = features.shape[1]
-            random_indices = torch.randperm(seq_len)[:seq_len - self.u_patchout].sort().values
+            random_indices = torch.randperm(seq_len)[: seq_len - self.u_patchout].sort().values
             features = features[:, random_indices, :]
 
         cls_tokens = self.cls_token.expand(B_dim, -1, -1) + self.new_pos_embed[:, :1, :]
@@ -283,12 +285,8 @@ class PaSST(BaseBackbone):
         else:
             return self.pre_logits(features[:, 2:])
 
-def adapt_image_pos_embed_to_passt(
-    posemb, 
-    num_tokens=1, 
-    gs_new=(), 
-    mode='bicubic'
-):
+
+def adapt_image_pos_embed_to_passt(posemb, num_tokens=1, gs_new=(), mode="bicubic"):
     """
     Adapt a 2D positional embedding from an image model to the PaSST spectrogram.
 
@@ -304,31 +302,26 @@ def adapt_image_pos_embed_to_passt(
             - freq_new_pos_embed: Frequency-wise positional embedding.
             - time_new_pos_embed: Time-wise positional embedding.
     """
-    
+
     if num_tokens:
         posemb_tok, posemb_grid = posemb[:, :num_tokens], posemb[0, num_tokens:]
     else:
         posemb_tok, posemb_grid = posemb[:, :0], posemb[0]
-        
+
     gs_old = int(math.sqrt(len(posemb_grid)))
 
-    if (len(gs_new) < 2):
+    if len(gs_new) < 2:
         raise ValueError(f"Variable gs_old can not be smaller than 2, given value: {gs_new}")
 
     posemb_grid = posemb_grid.reshape(1, gs_old, gs_old, -1).permute(0, 3, 1, 2)
     posemb_grid = F.interpolate(posemb_grid, size=gs_new, mode=mode, align_corners=False)
     freq_new_pos_embed = posemb_grid.mean(dim=3, keepdim=True)
     time_new_pos_embed = posemb_grid.mean(dim=2, keepdim=True)
-    
+
     return posemb_tok, freq_new_pos_embed, time_new_pos_embed
 
-def resize_pos_embed(
-    posemb, 
-    posemb_new, 
-    num_tokens=1, 
-    gs_new=(), 
-    mode='bicubic'
-):
+
+def resize_pos_embed(posemb, posemb_new, num_tokens=1, gs_new=(), mode="bicubic"):
     """
     Resize the positional embeddings to match a new model configuration.
 
@@ -358,5 +351,5 @@ def resize_pos_embed(
     posemb_grid = F.interpolate(posemb_grid, size=gs_new, mode=mode, align_corners=False)
     posemb_grid = posemb_grid.permute(0, 2, 3, 1).reshape(1, gs_new[0] * gs_new[1], -1)
     posemb = torch.cat([posemb_tok, posemb_grid], dim=1)
-    
+
     return posemb

--- a/src/deepaudiox/modules/backbones/passt/passt.py
+++ b/src/deepaudiox/modules/backbones/passt/passt.py
@@ -5,9 +5,7 @@ We tried to disentangle from the timm library version.
 Adapted from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
 
 """
-import logging
 import math
-import warnings
 from collections import OrderedDict
 from functools import partial
 
@@ -18,18 +16,49 @@ import torch.nn.functional as F
 from deepaudiox.modules.backbones.base_backbone import BaseBackbone
 from deepaudiox.modules.backbones.passt.modules import Block, PatchEmbed
 from deepaudiox.modules.backbones.passt.preprocess import AugmentMelSTFT
-from deepaudiox.modules.backbones.passt.vit_helpers import (
-    init_vit_weights,
-    load_pretrained_weights,
-    trunc_normal_,
-)
+from deepaudiox.modules.backbones.passt.vit_helpers import init_vit_weights, trunc_normal_
 
-# Global variables
-_logger = logging.getLogger()
 
 class PaSSTConfig:
+    """
+    Configuration class for PaSST (Patchout Spectrogram Transformer).
+
+    Stores all hyperparameters and settings for the PaSST model,
+    including model architecture, patch sizes, positional embeddings,
+    dropout rates, and other training-related options.
+
+    Args:
+        cfg (dict, optional): A dictionary of config overrides. Defaults to None.
+
+    Attributes:
+        num_classes (int): Number of output classes.
+        pool_size (tuple | None): Pooling size for feature maps.
+        crop_pct (float): Fraction of the image to crop when resizing.
+        interpolation (str): Interpolation method for resizing ('bicubic', 'bilinear', etc.).
+        fixed_input_size (bool): Whether the input size is fixed.
+        mean (tuple): Input normalization mean.
+        std (tuple): Input normalization std.
+        first_conv (str): Name of the first convolutional layer.
+        classifiers (tuple): Names of classifier layers.
+        u_patchout, s_patchout_t, s_patchout_f (int): Patchout parameters for data augmentation.
+        embed_dim (int): Embedding dimension.
+        distilled (bool): Whether to use knowledge distillation token.
+        pretrained (bool): Whether pretrained weights are used.
+        img_size (tuple): Input image/spectrogram size (frequency x time).
+        patch_size (int): Patch size.
+        fstride, tstride (int): Frequency and time stride for patching.
+        in_chans (int): Number of input channels.
+        depth (int): Number of transformer blocks.
+        num_heads (int): Number of attention heads.
+        mlp_ratio (float): Ratio of hidden dimension in MLP relative to embedding.
+        qkv_bias (bool): If True, include bias in Q/K/V projections.
+        representation_size (int | None): Size of the representation layer, if used.
+        drop_rate, attn_drop_rate, drop_path_rate (float): Dropout rates.
+        norm_layer, act_layer (nn.Module | None): Normalization and activation layers.
+        weight_init (str): Weight initialization method.
+    """
+
     def __init__(self, cfg=None):
-        self.url = 'https://github.com/kkoutini/PaSST/releases/download/v.0.0.9/passt-s-kd-ap.486.pt'
         self.num_classes = 527, 
         self.pool_size = None
         self.crop_pct = 1.0
@@ -66,16 +95,55 @@ class PaSSTConfig:
             self.update(cfg)
 
     def update(self, cfg: dict):
+        """
+        Update the configuration using a dictionary.
+
+        Args:
+            cfg (dict): Dictionary containing configuration keys and values to update.
+        """
         self.__dict__.update(cfg)
 
 class PaSST(BaseBackbone):
-    def __init__(
-        self, 
-        cfg: PaSSTConfig = PaSSTConfig(),
-        sample_rate: int = 16_000
-    ):
+    """
+    Patchout Spectrogram Transformer (PaSST) backbone.
+
+    A transformer-based model for audio classification that operates
+    on spectrogram inputs and uses patchout regularization. Supports
+    distillation tokens, positional embeddings in both time and frequency
+    dimensions, and multiple patchout strategies.
+
+    Pretrained checkpoint: https://github.com/kkoutini/PaSST/releases/download/v.0.0.9/passt-s-kd-ap.486.pt
+
+    Args:
+        cfg (PaSSTConfig | None): Model configuration. Defaults to None.
+        sample_rate (int): Input audio sample rate. Defaults to 16_000 Hz.
+
+    Attributes:
+        feature_extractor (nn.Module): Converts waveforms to spectrograms.
+        patch_embed (PatchEmbed): Converts spectrograms to patch embeddings.
+        cls_token (nn.Parameter): Class token embedding.
+        dist_token (nn.Parameter | None): Distillation token embedding.
+        new_pos_embed, freq_new_pos_embed, time_new_pos_embed (nn.Parameter): Positional embeddings.
+        blocks (nn.Sequential): Transformer blocks.
+        norm (nn.Module): Layer normalization applied to final features.
+        pre_logits (nn.Module): Optional representation layer before classifier.
+    """
+    
+    def __init__(self, cfg: PaSSTConfig | None = None, sample_rate: int = 16_000):
+        """_summary_
+
+        Args:
+            cfg (PaSSTConfig | None, optional): _description_. Defaults to None.
+            sample_rate (int, optional): _description_. Defaults to 16_000.
+
+        Raises:
+            ValueError: _description_
+        """
         super().__init__(out_dim=768, sample_rate=sample_rate)
-        self.cfg = cfg
+        if cfg is None:
+            self.cfg = PaSSTConfig()
+        else:
+            self.cfg = cfg
         self.feature_extractor = AugmentMelSTFT()
 
         self.num_classes = self.cfg.num_classes
@@ -144,25 +212,32 @@ class PaSST(BaseBackbone):
         trunc_normal_(self.cls_token, std=.02)
         self.apply(init_vit_weights)
 
-        # Load pre-trained weights
-        if self.cfg.url is not None:
-            load_pretrained_weights(
-                model = self,
-                pretrained_url = self.cfg.url,
-                num_classes = self.num_classes,
-                in_chans = self.cfg.in_chans,
-                filter_fn = checkpoint_filter_fn,
-                strict = True,
-                first_conv = self.cfg.first_conv,
-                classifiers = self.classifiers
-            )
-
     def extract_features(self, waveforms: torch.Tensor) -> torch.Tensor:
+        """
+        Convert raw audio waveforms into spectrogram features.
+
+        Args:
+            waveforms (torch.Tensor): Audio tensor of shape (batch, time).
+
+        Returns:
+            torch.Tensor: Spectrogram features of shape (batch, 1, freq, time).
+        """
         features = self.feature_extractor(waveforms)
         features = features.unsqueeze(1)
         return features
 
     def forward(self, features: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass of the PaSST backbone.
+
+        Args:
+            features (torch.Tensor): Input spectrogram features (batch, channels, freq, time).
+
+        Returns:
+            torch.Tensor: Transformer features after patch embedding, positional encoding, 
+                          transformer blocks, and normalization. Returns features excluding
+                          class/distillation tokens.
+        """
         features = self.patch_embed(features)
         B_dim, E_dim, F_dim, T_dim = features.shape 
         time_new_pos_embed = self.time_new_pos_embed
@@ -204,9 +279,9 @@ class PaSST(BaseBackbone):
         # else:
         #     return features[:, 0], features[:, 1]
         if self.dist_token is None:
-            return self.pre_logits(features)
+            return self.pre_logits(features[:, 1:])
         else:
-            return features
+            return self.pre_logits(features[:, 2:])
 
 def adapt_image_pos_embed_to_passt(
     posemb, 
@@ -214,9 +289,21 @@ def adapt_image_pos_embed_to_passt(
     gs_new=(), 
     mode='bicubic'
 ):
-    # Rescale the grid of position embeddings when loading from state_dict. Adapted from
-    # https://github.com/google-research/vision_transformer/blob/00883dd691c63a6830751563748663526e811cee/vit_jax/checkpoint.py#L224
-    _logger.info('Resized position embedding: %s to %s with %s cls/dis tokens', posemb.shape, gs_new, num_tokens)
+    """
+    Adapt a 2D positional embedding from an image model to the PaSST spectrogram.
+
+    Args:
+        posemb (torch.Tensor): Original positional embeddings (1, num_patches + num_tokens, dim).
+        num_tokens (int): Number of special tokens (class/distillation).
+        gs_new (tuple): New grid size (freq, time) for the spectrogram.
+        mode (str): Interpolation mode for resizing ('bicubic', 'bilinear', etc.).
+
+    Returns:
+        tuple: (posemb_tok, freq_new_pos_embed, time_new_pos_embed)
+            - posemb_tok: Token embeddings.
+            - freq_new_pos_embed: Frequency-wise positional embedding.
+            - time_new_pos_embed: Time-wise positional embedding.
+    """
     
     if num_tokens:
         posemb_tok, posemb_grid = posemb[:, :num_tokens], posemb[0, num_tokens:]
@@ -225,18 +312,13 @@ def adapt_image_pos_embed_to_passt(
         
     gs_old = int(math.sqrt(len(posemb_grid)))
 
-    assert len(gs_new) >= 2
-
-    _logger.info('Position embedding grid-size from %s to %s', [gs_old, gs_old], gs_new)
+    if (len(gs_new) < 2):
+        raise ValueError(f"Variable gs_old can not be smaller than 2, given value: {gs_new}")
 
     posemb_grid = posemb_grid.reshape(1, gs_old, gs_old, -1).permute(0, 3, 1, 2)
     posemb_grid = F.interpolate(posemb_grid, size=gs_new, mode=mode, align_corners=False)
     freq_new_pos_embed = posemb_grid.mean(dim=3, keepdim=True)
     time_new_pos_embed = posemb_grid.mean(dim=2, keepdim=True)
-
-    _logger.info('New Position cls/dstl embedding %s', posemb_tok.shape)
-    _logger.info('New FREQ Position embedding %s', freq_new_pos_embed.shape)
-    _logger.info('New TIME Position embedding %s', time_new_pos_embed.shape)
     
     return posemb_tok, freq_new_pos_embed, time_new_pos_embed
 
@@ -247,9 +329,21 @@ def resize_pos_embed(
     gs_new=(), 
     mode='bicubic'
 ):
-    # Rescale the grid of position embeddings when loading from state_dict. Adapted from
-    # https://github.com/google-research/vision_transformer/blob/00883dd691c63a6830751563748663526e811cee/vit_jax/checkpoint.py#L224
-    _logger.info('Resized position embedding: %s to %s with %s cls/dis tokens', posemb.shape, posemb_new.shape, num_tokens)
+    """
+    Resize the positional embeddings to match a new model configuration.
+
+    Used when loading pretrained weights from a different input resolution.
+
+    Args:
+        posemb (torch.Tensor): Original positional embeddings.
+        posemb_new (torch.Tensor): Target positional embeddings shape.
+        num_tokens (int): Number of special tokens.
+        gs_new (tuple): New grid size (freq, time). If empty, inferred from target.
+        mode (str): Interpolation mode for resizing.
+
+    Returns:
+        torch.Tensor: Resized positional embeddings.
+    """
     ntok_new = posemb_new.shape[1]
     if num_tokens:
         posemb_tok, posemb_grid = posemb[:, :num_tokens], posemb[0, num_tokens:]
@@ -259,79 +353,10 @@ def resize_pos_embed(
     gs_old = int(math.sqrt(len(posemb_grid)))
     if not len(gs_new):  # backwards compatibility
         gs_new = [int(math.sqrt(ntok_new))] * 2
-    assert len(gs_new) >= 2
-    _logger.info('Position embedding grid-size from %s to %s', [gs_old, gs_old], gs_new)
+
     posemb_grid = posemb_grid.reshape(1, gs_old, gs_old, -1).permute(0, 3, 1, 2)
     posemb_grid = F.interpolate(posemb_grid, size=gs_new, mode=mode, align_corners=False)
     posemb_grid = posemb_grid.permute(0, 2, 3, 1).reshape(1, gs_new[0] * gs_new[1], -1)
     posemb = torch.cat([posemb_tok, posemb_grid], dim=1)
+    
     return posemb
-
-def checkpoint_filter_fn(state_dict, model):
-    """
-    Convert patch embedding weights from manual patchify + linear projection
-    to convolution-based patch embedding and adapt positional embeddings.
-    """
-    out_dict = {}
-
-    # Handle checkpoints saved as {"model": state_dict}
-    if "model" in state_dict:
-        state_dict = state_dict["model"]
-
-    state_dict = {k: v for k, v in state_dict.items()}
-
-    # --------------------------------------------------
-    # Adapt ImageNet positional embeddings to PaSST
-    # --------------------------------------------------
-    if "time_new_pos_embed" not in state_dict:
-        _logger.info(
-            "Adapting pos embedding from ImageNet pretrained model to PaSST."
-        )
-
-        pos_embed = state_dict.pop("pos_embed")
-        (
-            new_pos_embed,
-            freq_new_pos_embed,
-            time_new_pos_embed,
-        ) = adapt_image_pos_embed_to_passt(
-            pos_embed,
-            getattr(model, "num_tokens", 1),
-            model.patch_embed.grid_size,
-        )
-
-        state_dict["new_pos_embed"] = new_pos_embed
-        state_dict["freq_new_pos_embed"] = freq_new_pos_embed
-        state_dict["time_new_pos_embed"] = time_new_pos_embed
-
-    # --------------------------------------------------
-    # Process remaining parameters
-    # --------------------------------------------------
-    for key, value in state_dict.items():
-        if "patch_embed.proj.weight" in key and value.ndim < 4:
-            # Old models: linear patch embedding → conv patch embedding
-            (
-                out_channels,
-                in_channels,
-                kernel_height,
-                kernel_width,
-            ) = model.patch_embed.proj.weight.shape
-
-            value = value.reshape(
-                out_channels,
-                -1,
-                kernel_height,
-                kernel_width,
-            )
-
-        elif key == "pos_embed" and value.shape != model.new_pos_embed.shape:
-            # Defensive resize (should rarely occur)
-            value = resize_pos_embed(
-                value,
-                model.new_pos_embed,
-                getattr(model, "num_tokens", 1),
-                model.patch_embed.grid_size,
-            )
-
-        out_dict[key] = value
-
-    return out_dict

--- a/src/deepaudiox/modules/backbones/passt/preprocess.py
+++ b/src/deepaudiox/modules/backbones/passt/preprocess.py
@@ -5,10 +5,10 @@ import torchaudio
 
 class AugmentMelSTFT(nn.Module):
     """
-    Computes a Mel-scaled spectrogram from audio waveforms with optional 
+    Computes a Mel-scaled spectrogram from audio waveforms with optional
     frequency and time masking for data augmentation.
 
-    This module applies pre-emphasis filtering, short-time Fourier transform 
+    This module applies pre-emphasis filtering, short-time Fourier transform
     (STFT), conversion to power spectrogram, Mel filterbank, log compression,
     and optional frequency/time masking augmentation during training.
 
@@ -27,21 +27,22 @@ class AugmentMelSTFT(nn.Module):
         fmin_aug_range (int): Frequency augmentation range for fmin. Must be >=1. Defaults to 10.
         fmax_aug_range (int): Frequency augmentation range for fmax. Must be >=1. Defaults to 2000.
     """
+
     def __init__(
         self,
-        n_mels = 128, 
-        sr = 32000, 
-        win_length = 800, 
-        hopsize = 320, 
-        n_fft = 1024, 
-        freqm = 48, 
-        timem = 192,
-        htk = False, 
-        fmin = 0.0, 
-        fmax = None, 
-        norm = 1, 
-        fmin_aug_range = 10, 
-        fmax_aug_range = 2000
+        n_mels=128,
+        sr=32000,
+        win_length=800,
+        hopsize=320,
+        n_fft=1024,
+        freqm=48,
+        timem=192,
+        htk=False,
+        fmin=0.0,
+        fmax=None,
+        norm=1,
+        fmin_aug_range=10,
+        fmax_aug_range=2000,
     ):
         torch.nn.Module.__init__(self)
         self.win_length = win_length
@@ -55,20 +56,16 @@ class AugmentMelSTFT(nn.Module):
         self.fmax = fmax
         self.norm = norm
         self.hopsize = hopsize
-        self.register_buffer(
-            'window',
-            torch.hann_window(win_length, periodic=False),
-            persistent=False
-        )
+        self.register_buffer("window", torch.hann_window(win_length, periodic=False), persistent=False)
         if fmin_aug_range < 1:
             raise ValueError(f"fmin_aug_range={fmin_aug_range} should be >=1; 1 means no augmentation")
         if fmax_aug_range < 1:
             raise ValueError(f"fmax_aug_range={fmax_aug_range} should be >=1; 1 means no augmentation")
-            
+
         self.fmin_aug_range = fmin_aug_range
         self.fmax_aug_range = fmax_aug_range
 
-        self.register_buffer("preemphasis_coefficient", torch.as_tensor([[[-.97, 1]]]), persistent=False)
+        self.register_buffer("preemphasis_coefficient", torch.as_tensor([[[-0.97, 1]]]), persistent=False)
         if freqm == 0:
             self.freqm = torch.nn.Identity()
         else:
@@ -91,17 +88,17 @@ class AugmentMelSTFT(nn.Module):
         """
         x = nn.functional.conv1d(x.unsqueeze(1), self.preemphasis_coefficient).squeeze(1)
         x = torch.stft(
-            x, 
-            self.n_fft, 
-            hop_length=self.hopsize, 
+            x,
+            self.n_fft,
+            hop_length=self.hopsize,
             win_length=self.win_length,
-            center=True, 
-            normalized=False, 
-            window=self.window, 
-            return_complex=True
+            center=True,
+            normalized=False,
+            window=self.window,
+            return_complex=True,
         )
         x = torch.view_as_real(x)
-        x = (x ** 2).sum(dim=-1)  # power mag
+        x = (x**2).sum(dim=-1)  # power mag
         fmin = self.fmin + torch.randint(self.fmin_aug_range, (1,)).item()
         fmax = self.fmax + self.fmax_aug_range // 2 - torch.randint(self.fmax_aug_range, (1,)).item()
         # don't augment eval data
@@ -110,22 +107,10 @@ class AugmentMelSTFT(nn.Module):
             fmax = self.fmax
 
         mel_basis, _ = torchaudio.compliance.kaldi.get_mel_banks(
-            self.n_mels,  
-            self.n_fft, 
-            self.sr,
-            fmin, 
-            fmax, 
-            vtln_low=100.0, 
-            vtln_high=-500., 
-            vtln_warp_factor=1.0
+            self.n_mels, self.n_fft, self.sr, fmin, fmax, vtln_low=100.0, vtln_high=-500.0, vtln_warp_factor=1.0
         )
         mel_basis = torch.as_tensor(
-            torch.nn.functional.pad(
-                mel_basis, (0, 1), 
-                mode='constant', 
-                value=0
-            ),
-             device=x.device
+            torch.nn.functional.pad(mel_basis, (0, 1), mode="constant", value=0), device=x.device
         )
         with torch.amp.autocast("cuda", enabled=False):
             melspec = torch.matmul(mel_basis, x)
@@ -136,7 +121,7 @@ class AugmentMelSTFT(nn.Module):
             melspec = self.freqm(melspec)
             melspec = self.timem(melspec)
 
-        melspec = (melspec + 4.5) / 5.  # fast normalization
+        melspec = (melspec + 4.5) / 5.0  # fast normalization
 
         return melspec
 
@@ -147,5 +132,4 @@ class AugmentMelSTFT(nn.Module):
         Returns:
             str: Information about window and hop size.
         """
-        return f'winsize={self.win_length}, hopsize={self.hopsize}'
-
+        return f"winsize={self.win_length}, hopsize={self.hopsize}"

--- a/src/deepaudiox/modules/backbones/passt/preprocess.py
+++ b/src/deepaudiox/modules/backbones/passt/preprocess.py
@@ -117,7 +117,7 @@ class AugmentMelSTFT(nn.Module):
         mel_basis = torch.as_tensor(
             torch.nn.functional.pad(mel_basis, (0, 1), mode="constant", value=0), device=x.device
         )
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast("cuda", enabled=False):
             melspec = torch.matmul(mel_basis, x)
 
         melspec = (melspec + 0.00001).log()

--- a/src/deepaudiox/modules/backbones/passt/preprocess.py
+++ b/src/deepaudiox/modules/backbones/passt/preprocess.py
@@ -2,7 +2,31 @@ import torch
 import torch.nn as nn
 import torchaudio
 
+
 class AugmentMelSTFT(nn.Module):
+    """
+    Computes a Mel-scaled spectrogram from audio waveforms with optional 
+    frequency and time masking for data augmentation.
+
+    This module applies pre-emphasis filtering, short-time Fourier transform 
+    (STFT), conversion to power spectrogram, Mel filterbank, log compression,
+    and optional frequency/time masking augmentation during training.
+
+    Args:
+        n_mels (int): Number of Mel bands. Defaults to 128.
+        sr (int): Sampling rate of input audio. Defaults to 32000.
+        win_length (int): Window size for STFT. Defaults to 800.
+        hopsize (int): Hop size for STFT. Defaults to 320.
+        n_fft (int): Number of FFT points. Defaults to 1024.
+        freqm (int): Maximum width for frequency masking. 0 disables masking. Defaults to 48.
+        timem (int): Maximum width for time masking. 0 disables masking. Defaults to 192.
+        htk (bool): Whether to use HTK formula for Mel scale. Defaults to False.
+        fmin (float): Minimum frequency for Mel scale. Defaults to 0.0 Hz.
+        fmax (float): Maximum frequency for Mel scale. Defaults to sr/2 minus half of fmax_aug_range.
+        norm (int): Normalization mode for Mel filterbanks. Defaults to 1.
+        fmin_aug_range (int): Frequency augmentation range for fmin. Must be >=1. Defaults to 10.
+        fmax_aug_range (int): Frequency augmentation range for fmax. Must be >=1. Defaults to 2000.
+    """
     def __init__(
         self,
         n_mels = 128, 
@@ -20,8 +44,6 @@ class AugmentMelSTFT(nn.Module):
         fmax_aug_range = 2000
     ):
         torch.nn.Module.__init__(self)
-        # adapted from: https://github.com/CPJKU/kagglebirds2020/commit/70f8308b39011b09d41eb0f4ace5aa7d2b0e806e
-        # Similar config to the spectrograms used in AST: https://github.com/YuanGongND/ast
         self.win_length = win_length
         self.n_mels = n_mels
         self.n_fft = n_fft
@@ -30,7 +52,6 @@ class AugmentMelSTFT(nn.Module):
         self.fmin = fmin
         if fmax is None:
             fmax = sr // 2 - fmax_aug_range // 2
-            print(f"Warning: FMAX is None setting to {fmax} ")
         self.fmax = fmax
         self.norm = norm
         self.hopsize = hopsize
@@ -39,8 +60,11 @@ class AugmentMelSTFT(nn.Module):
             torch.hann_window(win_length, periodic=False),
             persistent=False
         )
-        assert fmin_aug_range >= 1, f"fmin_aug_range={fmin_aug_range} should be >=1; 1 means no augmentation"
-        assert fmin_aug_range >= 1, f"fmax_aug_range={fmax_aug_range} should be >=1; 1 means no augmentation"
+        if fmin_aug_range < 1:
+            raise ValueError(f"fmin_aug_range={fmin_aug_range} should be >=1; 1 means no augmentation")
+        if fmax_aug_range < 1:
+            raise ValueError(f"fmax_aug_range={fmax_aug_range} should be >=1; 1 means no augmentation")
+            
         self.fmin_aug_range = fmin_aug_range
         self.fmax_aug_range = fmax_aug_range
 
@@ -55,6 +79,16 @@ class AugmentMelSTFT(nn.Module):
             self.timem = torchaudio.transforms.TimeMasking(timem, iid_masks=True)
 
     def forward(self, x):
+        """
+        Compute augmented Mel spectrogram.
+
+        Args:
+            x (torch.Tensor): Input waveform tensor of shape (batch, time).
+
+        Returns:
+            torch.Tensor: Mel spectrogram tensor of shape (batch, n_mels, time_frames),
+                          log-compressed and optionally augmented during training.
+        """
         x = nn.functional.conv1d(x.unsqueeze(1), self.preemphasis_coefficient).squeeze(1)
         x = torch.stft(
             x, 
@@ -64,8 +98,9 @@ class AugmentMelSTFT(nn.Module):
             center=True, 
             normalized=False, 
             window=self.window, 
-            return_complex=False
+            return_complex=True
         )
+        x = torch.view_as_real(x)
         x = (x ** 2).sum(dim=-1)  # power mag
         fmin = self.fmin + torch.randint(self.fmin_aug_range, (1,)).item()
         fmax = self.fmax + self.fmax_aug_range // 2 - torch.randint(self.fmax_aug_range, (1,)).item()
@@ -92,7 +127,7 @@ class AugmentMelSTFT(nn.Module):
             ),
              device=x.device
         )
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast("cuda", enabled=False):
             melspec = torch.matmul(mel_basis, x)
 
         melspec = (melspec + 0.00001).log()
@@ -106,5 +141,11 @@ class AugmentMelSTFT(nn.Module):
         return melspec
 
     def extra_repr(self):
+        """
+        Extra representation for printing.
+
+        Returns:
+            str: Information about window and hop size.
+        """
         return f'winsize={self.win_length}, hopsize={self.hopsize}'
 

--- a/src/deepaudiox/modules/backbones/passt/preprocess.py
+++ b/src/deepaudiox/modules/backbones/passt/preprocess.py
@@ -1,0 +1,110 @@
+import torch
+import torch.nn as nn
+import torchaudio
+
+class AugmentMelSTFT(nn.Module):
+    def __init__(
+        self,
+        n_mels = 128, 
+        sr = 32000, 
+        win_length = 800, 
+        hopsize = 320, 
+        n_fft = 1024, 
+        freqm = 48, 
+        timem = 192,
+        htk = False, 
+        fmin = 0.0, 
+        fmax = None, 
+        norm = 1, 
+        fmin_aug_range = 10, 
+        fmax_aug_range = 2000
+    ):
+        torch.nn.Module.__init__(self)
+        # adapted from: https://github.com/CPJKU/kagglebirds2020/commit/70f8308b39011b09d41eb0f4ace5aa7d2b0e806e
+        # Similar config to the spectrograms used in AST: https://github.com/YuanGongND/ast
+        self.win_length = win_length
+        self.n_mels = n_mels
+        self.n_fft = n_fft
+        self.sr = sr
+        self.htk = htk
+        self.fmin = fmin
+        if fmax is None:
+            fmax = sr // 2 - fmax_aug_range // 2
+            print(f"Warning: FMAX is None setting to {fmax} ")
+        self.fmax = fmax
+        self.norm = norm
+        self.hopsize = hopsize
+        self.register_buffer(
+            'window',
+            torch.hann_window(win_length, periodic=False),
+            persistent=False
+        )
+        assert fmin_aug_range >= 1, f"fmin_aug_range={fmin_aug_range} should be >=1; 1 means no augmentation"
+        assert fmin_aug_range >= 1, f"fmax_aug_range={fmax_aug_range} should be >=1; 1 means no augmentation"
+        self.fmin_aug_range = fmin_aug_range
+        self.fmax_aug_range = fmax_aug_range
+
+        self.register_buffer("preemphasis_coefficient", torch.as_tensor([[[-.97, 1]]]), persistent=False)
+        if freqm == 0:
+            self.freqm = torch.nn.Identity()
+        else:
+            self.freqm = torchaudio.transforms.FrequencyMasking(freqm, iid_masks=True)
+        if timem == 0:
+            self.timem = torch.nn.Identity()
+        else:
+            self.timem = torchaudio.transforms.TimeMasking(timem, iid_masks=True)
+
+    def forward(self, x):
+        x = nn.functional.conv1d(x.unsqueeze(1), self.preemphasis_coefficient).squeeze(1)
+        x = torch.stft(
+            x, 
+            self.n_fft, 
+            hop_length=self.hopsize, 
+            win_length=self.win_length,
+            center=True, 
+            normalized=False, 
+            window=self.window, 
+            return_complex=False
+        )
+        x = (x ** 2).sum(dim=-1)  # power mag
+        fmin = self.fmin + torch.randint(self.fmin_aug_range, (1,)).item()
+        fmax = self.fmax + self.fmax_aug_range // 2 - torch.randint(self.fmax_aug_range, (1,)).item()
+        # don't augment eval data
+        if not self.training:
+            fmin = self.fmin
+            fmax = self.fmax
+
+        mel_basis, _ = torchaudio.compliance.kaldi.get_mel_banks(
+            self.n_mels,  
+            self.n_fft, 
+            self.sr,
+            fmin, 
+            fmax, 
+            vtln_low=100.0, 
+            vtln_high=-500., 
+            vtln_warp_factor=1.0
+        )
+        mel_basis = torch.as_tensor(
+            torch.nn.functional.pad(
+                mel_basis, (0, 1), 
+                mode='constant', 
+                value=0
+            ),
+             device=x.device
+        )
+        with torch.cuda.amp.autocast(enabled=False):
+            melspec = torch.matmul(mel_basis, x)
+
+        melspec = (melspec + 0.00001).log()
+
+        if self.training:
+            melspec = self.freqm(melspec)
+            melspec = self.timem(melspec)
+
+        melspec = (melspec + 4.5) / 5.  # fast normalization
+
+        return melspec
+
+    def extra_repr(self):
+        return f'winsize={self.win_length}, hopsize={self.hopsize}'
+

--- a/src/deepaudiox/modules/backbones/passt/preprocess.py
+++ b/src/deepaudiox/modules/backbones/passt/preprocess.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import torch
 import torch.nn as nn
 import torchaudio
@@ -86,7 +88,10 @@ class AugmentMelSTFT(nn.Module):
             torch.Tensor: Mel spectrogram tensor of shape (batch, n_mels, time_frames),
                           log-compressed and optionally augmented during training.
         """
-        x = nn.functional.conv1d(x.unsqueeze(1), self.preemphasis_coefficient).squeeze(1)
+        x = nn.functional.conv1d(
+            x.unsqueeze(1),
+            cast(torch.Tensor, self.preemphasis_coefficient),
+        ).squeeze(1)
         x = torch.stft(
             x,
             self.n_fft,
@@ -94,7 +99,7 @@ class AugmentMelSTFT(nn.Module):
             win_length=self.win_length,
             center=True,
             normalized=False,
-            window=self.window,
+            window=cast(torch.Tensor, self.window),
             return_complex=True,
         )
         x = torch.view_as_real(x)
@@ -112,7 +117,7 @@ class AugmentMelSTFT(nn.Module):
         mel_basis = torch.as_tensor(
             torch.nn.functional.pad(mel_basis, (0, 1), mode="constant", value=0), device=x.device
         )
-        with torch.amp.autocast("cuda", enabled=False):
+        with torch.cuda.amp.autocast(enabled=False):
             melspec = torch.matmul(mel_basis, x)
 
         melspec = (melspec + 0.00001).log()

--- a/src/deepaudiox/modules/backbones/passt/vit_helpers.py
+++ b/src/deepaudiox/modules/backbones/passt/vit_helpers.py
@@ -3,6 +3,7 @@ Adapted from https://github.com/rwightman/pytorch-image-models/blob/master/timm/
 Credit to @leo19941227  for remove timm dependencies here : https://github.com/s3prl/passt_hear21/blob/48a0dc1b824641ca59884ced53f5b86053fed141/hear21passt/models/helpers/vit_helpers.py
 
 """
+
 import math
 
 import torch
@@ -10,17 +11,12 @@ from torch import nn
 from torch.nn.init import _calculate_fan_in_and_fan_out
 
 
-def init_vit_weights(
-    module: nn.Module, 
-    name: str = '', 
-    head_bias: float = 0., 
-    jax_impl: bool = False
-):
+def init_vit_weights(module: nn.Module, name: str = "", head_bias: float = 0.0, jax_impl: bool = False):
     """
     Initialize weights for Vision Transformer (ViT) modules.
 
-    This function handles initialization for Linear layers, Conv2d layers, 
-    and normalization layers according to the original ViT / DeiT schemes.  
+    This function handles initialization for Linear layers, Conv2d layers,
+    and normalization layers according to the original ViT / DeiT schemes.
     It optionally matches the JAX implementation of ViT when `jax_impl=True`.
 
     Args:
@@ -29,24 +25,24 @@ def init_vit_weights(
         head_bias (float, optional): Bias for classifier heads. Defaults to 0.
         jax_impl (bool, optional): Whether to use initialization compatible with JAX ViT. Defaults to False.
     """
-    
+
     if isinstance(module, nn.Linear):
-        if name.startswith('head'):
+        if name.startswith("head"):
             nn.init.zeros_(module.weight)
             nn.init.constant_(module.bias, head_bias)
-        elif name.startswith('pre_logits'):
+        elif name.startswith("pre_logits"):
             lecun_normal_(module.weight)
             nn.init.zeros_(module.bias)
         else:
             if jax_impl:
                 nn.init.xavier_uniform_(module.weight)
                 if module.bias is not None:
-                    if 'mlp' in name:
+                    if "mlp" in name:
                         nn.init.normal_(module.bias, std=1e-6)
                     else:
                         nn.init.zeros_(module.bias)
             else:
-                trunc_normal_(module.weight, std=.02)
+                trunc_normal_(module.weight, std=0.02)
                 if module.bias is not None:
                     nn.init.zeros_(module.bias)
     elif jax_impl and isinstance(module, nn.Conv2d):
@@ -57,6 +53,7 @@ def init_vit_weights(
     elif isinstance(module, (nn.LayerNorm, nn.GroupNorm, nn.BatchNorm2d)):
         nn.init.zeros_(module.bias)
         nn.init.ones_(module.weight)
+
 
 def adapt_input_conv(in_chans: int, conv_weight: torch.Tensor) -> torch.Tensor:
     """
@@ -69,7 +66,7 @@ def adapt_input_conv(in_chans: int, conv_weight: torch.Tensor) -> torch.Tensor:
 
     Args:
         in_chans (int): Number of input channels for the new model.
-        conv_weight (torch.Tensor): Pretrained Conv2d weight tensor 
+        conv_weight (torch.Tensor): Pretrained Conv2d weight tensor
                                     of shape (out_channels, in_channels, kernel_h, kernel_w)
 
     Returns:
@@ -107,9 +104,7 @@ def adapt_input_conv(in_chans: int, conv_weight: torch.Tensor) -> torch.Tensor:
     elif in_chans != 3:
         # Adapt RGB weights to arbitrary number of input channels
         if in_channels != 3:
-            raise NotImplementedError(
-                "Weight format not supported for non-RGB input."
-            )
+            raise NotImplementedError("Weight format not supported for non-RGB input.")
 
         repeat = int(math.ceil(in_chans / 3))
         conv_weight = conv_weight.repeat(1, repeat, 1, 1)[:, :in_chans, :, :]
@@ -119,6 +114,7 @@ def adapt_input_conv(in_chans: int, conv_weight: torch.Tensor) -> torch.Tensor:
     conv_weight = conv_weight.to(original_dtype)
 
     return conv_weight
+
 
 def drop_path(x, drop_prob: float = 0.0, training: bool = False):
     """
@@ -137,9 +133,7 @@ def drop_path(x, drop_prob: float = 0.0, training: bool = False):
     if drop_prob == 0.0 or not training:
         return x
     keep_prob = 1 - drop_prob
-    shape = (x.shape[0],) + (1,) * (
-        x.ndim - 1
-    )  # work with diff dim tensors, not just 2D ConvNets
+    shape = (x.shape[0],) + (1,) * (x.ndim - 1)  # work with diff dim tensors, not just 2D ConvNets
     random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
     random_tensor.floor_()  # binarize
     output = x.div(keep_prob) * random_tensor
@@ -161,12 +155,14 @@ class DropPath(nn.Module):
     Returns:
         torch.Tensor: Tensor with stochastic depth applied.
     """
+
     def __init__(self, drop_prob=None):
         super().__init__()
         self.drop_prob = drop_prob
 
     def forward(self, x):
         return drop_path(x, self.drop_prob, self.training)
+
 
 def _no_grad_trunc_normal_(tensor, mean, std, a, b):
     """
@@ -183,6 +179,7 @@ def _no_grad_trunc_normal_(tensor, mean, std, a, b):
     Returns:
         torch.Tensor: The same tensor filled in-place.
     """
+
     def norm_cdf(x):
         """
         Standard normal cumulative distribution function.
@@ -248,7 +245,7 @@ def variance_scaling_(tensor, scale=1.0, mode="fan_in", distribution="normal"):
         tensor (torch.Tensor): Tensor to initialize.
         scale (float, optional): Scaling factor. Defaults to 1.0.
         mode (str, optional): One of ['fan_in', 'fan_out', 'fan_avg']. Defaults to 'fan_in'.
-        distribution (str, optional): Distribution type. One of ['normal', 'truncated_normal', 'uniform']. 
+        distribution (str, optional): Distribution type. One of ['normal', 'truncated_normal', 'uniform'].
                                         Defaults to 'normal'.
 
     Raises:
@@ -274,6 +271,7 @@ def variance_scaling_(tensor, scale=1.0, mode="fan_in", distribution="normal"):
         tensor.uniform_(-bound, bound)
     else:
         raise ValueError(f"invalid distribution {distribution}")
+
 
 def lecun_normal_(tensor):
     """

--- a/src/deepaudiox/modules/backbones/passt/vit_helpers.py
+++ b/src/deepaudiox/modules/backbones/passt/vit_helpers.py
@@ -1,0 +1,317 @@
+"""
+Adapted from https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py
+Credit to @leo19941227  for remove timm dependencies here : https://github.com/s3prl/passt_hear21/blob/48a0dc1b824641ca59884ced53f5b86053fed141/hear21passt/models/helpers/vit_helpers.py
+
+"""
+import logging
+import math
+import warnings
+
+import torch
+from torch import nn
+
+try:
+    from timm.models._hub import download_cached_file
+except ModuleNotFoundError:
+    from timm.models.hub import download_cached_file
+from torch.nn.init import _calculate_fan_in_and_fan_out
+
+# Global variables for rarely used pretrained checkpoint download progress and hash check.
+# Use set_pretrained_download_progress / set_pretrained_check_hash functions to toggle.
+_DOWNLOAD_PROGRESS = True
+_CHECK_HASH = False
+
+
+_logger = logging.getLogger(__name__)
+
+
+def init_vit_weights(
+    module: nn.Module, 
+    name: str = '', 
+    head_bias: float = 0., 
+    jax_impl: bool = False
+):
+    """ ViT weight initialization
+    * When called without n, head_bias, jax_impl args it will behave exactly the same
+    as my original init for compatibility with prev hparam / downstream use cases (ie DeiT).
+    * When called w/ valid n (module name) and jax_impl=True, will (hopefully) match JAX impl
+    """
+    if isinstance(module, nn.Linear):
+        if name.startswith('head'):
+            nn.init.zeros_(module.weight)
+            nn.init.constant_(module.bias, head_bias)
+        elif name.startswith('pre_logits'):
+            lecun_normal_(module.weight)
+            nn.init.zeros_(module.bias)
+        else:
+            if jax_impl:
+                nn.init.xavier_uniform_(module.weight)
+                if module.bias is not None:
+                    if 'mlp' in name:
+                        nn.init.normal_(module.bias, std=1e-6)
+                    else:
+                        nn.init.zeros_(module.bias)
+            else:
+                trunc_normal_(module.weight, std=.02)
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+    elif jax_impl and isinstance(module, nn.Conv2d):
+        # NOTE conv was left to pytorch default in my original init
+        lecun_normal_(module.weight)
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+    elif isinstance(module, (nn.LayerNorm, nn.GroupNorm, nn.BatchNorm2d)):
+        nn.init.zeros_(module.bias)
+        nn.init.ones_(module.weight)
+
+def adapt_input_conv(in_chans: int, conv_weight: torch.Tensor) -> torch.Tensor:
+    """
+    Adapt pretrained Conv2d weights to a different number of input channels.
+
+    Args:
+        in_chans: Number of input channels for the new model.
+        conv_weight: Conv2d weight tensor of shape
+                     (out_channels, in_channels, kernel_height, kernel_width)
+
+    Returns:
+        Adapted convolution weight tensor.
+    """
+    original_dtype = conv_weight.dtype
+
+    # Ensure float32 for safe summation on CPU
+    conv_weight = conv_weight.float()
+
+    out_channels, in_channels, kernel_height, kernel_width = conv_weight.shape
+
+    if in_chans == 1:
+        # Convert RGB (or space2depth) weights to single-channel
+        if in_channels > 3:
+            # space2depth stem (channels divisible by 3)
+            assert in_channels % 3 == 0
+            conv_weight = conv_weight.reshape(
+                out_channels,
+                in_channels // 3,
+                3,
+                kernel_height,
+                kernel_width,
+            )
+            conv_weight = conv_weight.sum(dim=2)
+        else:
+            # Standard RGB → grayscale
+            conv_weight = conv_weight.sum(dim=1, keepdim=True)
+
+    elif in_chans != 3:
+        # Adapt RGB weights to arbitrary number of input channels
+        if in_channels != 3:
+            raise NotImplementedError(
+                "Weight format not supported for non-RGB input."
+            )
+
+        repeat = int(math.ceil(in_chans / 3))
+        conv_weight = conv_weight.repeat(1, repeat, 1, 1)[:, :in_chans, :, :]
+        conv_weight *= 3.0 / float(in_chans)
+
+    # Restore original dtype (e.g. float16)
+    conv_weight = conv_weight.to(original_dtype)
+
+    return conv_weight
+
+
+def load_pretrained_weights(
+    model: nn.Module,
+    first_conv: str | None = None,
+    pretrained_url: str | None = None,
+    filter_fn=None,
+    num_classes: int = 1000,
+    in_chans: int =3,
+    strict: bool = False,
+    progress: bool = False,
+    classifiers: tuple | None = None,
+    label_offset: int = 0
+):
+    """Load pretrained checkpoint
+
+    Args:
+        model (nn.Module) : PyTorch model module
+        default_cfg (Optional[Dict]): default configuration for pretrained weights / target dataset
+        num_classes (int): num_classes for model
+        in_chans (int): in_chans for model
+        filter_fn (Optional[Callable]): state_dict filter fn for load (takes state_dict, model as args)
+        strict (bool): strict load of checkpoint
+        progress (bool): enable progress bar for weight download
+
+    """
+    if not pretrained_url:
+        _logger.warning(
+            "No pretrained weights exist for this model. Using random initialization."
+        )
+        return
+
+    _logger.info(f"Loading pretrained weights from url ({pretrained_url})")
+    
+    pretrained_loc = download_cached_file(
+        pretrained_url,
+        check_hash=_CHECK_HASH,
+        progress=_DOWNLOAD_PROGRESS,
+    )
+
+    state_dict = torch.load(pretrained_loc, map_location="cpu")
+
+    if filter_fn is not None:
+        # for backwards compat with filter fn that take one arg, try one first, the two
+        try:
+            state_dict = filter_fn(state_dict)
+        except TypeError:
+            state_dict = filter_fn(state_dict, model)
+
+    input_convs = first_conv
+    if input_convs is not None and in_chans != 3:
+        if isinstance(input_convs, str):
+            input_convs = (input_convs,)
+        for input_conv_name in input_convs:
+            weight_name = input_conv_name + ".weight"
+            try:
+                state_dict[weight_name] = adapt_input_conv(
+                    in_chans, state_dict[weight_name]
+                )
+                _logger.info(
+                    f"Converted input conv {input_conv_name} pretrained weights from 3 to {in_chans} channel(s)"
+                )
+            except NotImplementedError:
+                del state_dict[weight_name]
+                strict = False
+                _logger.warning(
+                    f"Unable to convert pretrained {input_conv_name} weights, using random init for this layer."
+                )
+
+    if classifiers is not None:
+        if isinstance(classifiers, str):
+            classifiers = (classifiers,)
+
+        # Always drop classifier heads for backbone usage
+        for classifier_name in classifiers:
+            for suffix in ("weight", "bias"):
+                key = f"{classifier_name}.{suffix}"
+                if key in state_dict:
+                    del state_dict[key]
+
+        strict = False
+
+    model.load_state_dict(state_dict, strict=strict)
+
+
+def drop_path(x, drop_prob: float = 0.0, training: bool = False):
+    """Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
+
+    This is the same as the DropConnect impl I created for EfficientNet, etc networks, however,
+    the original name is misleading as 'Drop Connect' is a different form of dropout in a separate paper...
+    See discussion: https://github.com/tensorflow/tpu/issues/494#issuecomment-532968956 ... I've opted for
+    changing the layer and argument names to 'drop path' rather than mix DropConnect as a layer name and use
+    'survival rate' as the argument.
+
+    """
+    if drop_prob == 0.0 or not training:
+        return x
+    keep_prob = 1 - drop_prob
+    shape = (x.shape[0],) + (1,) * (
+        x.ndim - 1
+    )  # work with diff dim tensors, not just 2D ConvNets
+    random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
+    random_tensor.floor_()  # binarize
+    output = x.div(keep_prob) * random_tensor
+    return output
+
+
+class DropPath(nn.Module):
+    """Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks)."""
+
+    def __init__(self, drop_prob=None):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x):
+        return drop_path(x, self.drop_prob, self.training)
+
+def _no_grad_trunc_normal_(tensor, mean, std, a, b):
+    # Cut & paste from PyTorch official master until it's in a few official releases - RW
+    # Method based on https://people.sc.fsu.edu/~jburkardt/presentations/truncated_normal.pdf
+    def norm_cdf(x):
+        # Computes standard normal cumulative distribution function
+        return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
+
+    if (mean < a - 2 * std) or (mean > b + 2 * std):
+        warnings.warn(
+            "mean is more than 2 std from [a, b] in nn.init.trunc_normal_. "
+            "The distribution of values may be incorrect.",
+            stacklevel=2,
+        )
+
+    with torch.no_grad():
+        # Values are generated by using a truncated uniform distribution and
+        # then using the inverse CDF for the normal distribution.
+        # Get upper and lower cdf values
+        lower = norm_cdf((a - mean) / std)
+        upper = norm_cdf((b - mean) / std)
+
+        # Uniformly fill tensor with values from [l, u], then translate to
+        # [2l-1, 2u-1].
+        tensor.uniform_(2 * lower - 1, 2 * upper - 1)
+
+        # Use inverse cdf transform for normal distribution to get truncated
+        # standard normal
+        tensor.erfinv_()
+
+        # Transform to proper mean, std
+        tensor.mul_(std * math.sqrt(2.0))
+        tensor.add_(mean)
+
+        # Clamp to ensure it's in the proper range
+        tensor.clamp_(min=a, max=b)
+        return tensor
+
+
+def trunc_normal_(tensor, mean=0.0, std=1.0, a=-2.0, b=2.0):
+    r"""Fills the input Tensor with values drawn from a truncated
+    normal distribution. The values are effectively drawn from the
+    normal distribution :math:`\mathcal{N}(\text{mean}, \text{std}^2)`
+    with values outside :math:`[a, b]` redrawn until they are within
+    the bounds. The method used for generating the random values works
+    best when :math:`a \leq \text{mean} \leq b`.
+    Args:
+        tensor: an n-dimensional `torch.Tensor`
+        mean: the mean of the normal distribution
+        std: the standard deviation of the normal distribution
+        a: the minimum cutoff value
+        b: the maximum cutoff value
+    Examples:
+        >>> w = torch.empty(3, 5)
+        >>> nn.init.trunc_normal_(w)
+    """
+    return _no_grad_trunc_normal_(tensor, mean, std, a, b)
+
+
+def variance_scaling_(tensor, scale=1.0, mode="fan_in", distribution="normal"):
+    fan_in, fan_out = _calculate_fan_in_and_fan_out(tensor)
+    if mode == "fan_in":
+        denom = fan_in
+    elif mode == "fan_out":
+        denom = fan_out
+    elif mode == "fan_avg":
+        denom = (fan_in + fan_out) / 2
+
+    variance = scale / denom
+
+    if distribution == "truncated_normal":
+        # constant is stddev of standard normal truncated to (-2, 2)
+        trunc_normal_(tensor, std=math.sqrt(variance) / 0.87962566103423978)
+    elif distribution == "normal":
+        tensor.normal_(std=math.sqrt(variance))
+    elif distribution == "uniform":
+        bound = math.sqrt(3 * variance)
+        tensor.uniform_(-bound, bound)
+    else:
+        raise ValueError(f"invalid distribution {distribution}")
+
+
+def lecun_normal_(tensor):
+    variance_scaling_(tensor, mode="fan_in", distribution="truncated_normal")

--- a/src/deepaudiox/modules/backbones/passt/vit_helpers.py
+++ b/src/deepaudiox/modules/backbones/passt/vit_helpers.py
@@ -3,26 +3,11 @@ Adapted from https://github.com/rwightman/pytorch-image-models/blob/master/timm/
 Credit to @leo19941227  for remove timm dependencies here : https://github.com/s3prl/passt_hear21/blob/48a0dc1b824641ca59884ced53f5b86053fed141/hear21passt/models/helpers/vit_helpers.py
 
 """
-import logging
 import math
-import warnings
 
 import torch
 from torch import nn
-
-try:
-    from timm.models._hub import download_cached_file
-except ModuleNotFoundError:
-    from timm.models.hub import download_cached_file
 from torch.nn.init import _calculate_fan_in_and_fan_out
-
-# Global variables for rarely used pretrained checkpoint download progress and hash check.
-# Use set_pretrained_download_progress / set_pretrained_check_hash functions to toggle.
-_DOWNLOAD_PROGRESS = True
-_CHECK_HASH = False
-
-
-_logger = logging.getLogger(__name__)
 
 
 def init_vit_weights(
@@ -31,11 +16,20 @@ def init_vit_weights(
     head_bias: float = 0., 
     jax_impl: bool = False
 ):
-    """ ViT weight initialization
-    * When called without n, head_bias, jax_impl args it will behave exactly the same
-    as my original init for compatibility with prev hparam / downstream use cases (ie DeiT).
-    * When called w/ valid n (module name) and jax_impl=True, will (hopefully) match JAX impl
     """
+    Initialize weights for Vision Transformer (ViT) modules.
+
+    This function handles initialization for Linear layers, Conv2d layers, 
+    and normalization layers according to the original ViT / DeiT schemes.  
+    It optionally matches the JAX implementation of ViT when `jax_impl=True`.
+
+    Args:
+        module (nn.Module): Module to initialize (Linear, Conv2d, or Norm layer).
+        name (str, optional): Module name used to differentiate heads, pre_logits, etc.
+        head_bias (float, optional): Bias for classifier heads. Defaults to 0.
+        jax_impl (bool, optional): Whether to use initialization compatible with JAX ViT. Defaults to False.
+    """
+    
     if isinstance(module, nn.Linear):
         if name.startswith('head'):
             nn.init.zeros_(module.weight)
@@ -66,15 +60,24 @@ def init_vit_weights(
 
 def adapt_input_conv(in_chans: int, conv_weight: torch.Tensor) -> torch.Tensor:
     """
-    Adapt pretrained Conv2d weights to a different number of input channels.
+    Adapt a pretrained Conv2d weight tensor to a different number of input channels.
+
+    Supports:
+        - RGB → Grayscale (sum channels)
+        - Space2Depth stems
+        - Arbitrary number of channels via repetition
 
     Args:
-        in_chans: Number of input channels for the new model.
-        conv_weight: Conv2d weight tensor of shape
-                     (out_channels, in_channels, kernel_height, kernel_width)
+        in_chans (int): Number of input channels for the new model.
+        conv_weight (torch.Tensor): Pretrained Conv2d weight tensor 
+                                    of shape (out_channels, in_channels, kernel_h, kernel_w)
 
     Returns:
-        Adapted convolution weight tensor.
+        torch.Tensor: Adapted Conv2d weight tensor.
+
+    Raises:
+        ValueError: If in_channels not divisible by 3 for Space2Depth.
+        NotImplementedError: If unsupported input channel configuration is provided.
     """
     original_dtype = conv_weight.dtype
 
@@ -87,7 +90,8 @@ def adapt_input_conv(in_chans: int, conv_weight: torch.Tensor) -> torch.Tensor:
         # Convert RGB (or space2depth) weights to single-channel
         if in_channels > 3:
             # space2depth stem (channels divisible by 3)
-            assert in_channels % 3 == 0
+            if in_channels % 3 != 0:
+                raise ValueError(f"in_channels={in_channels} must be divisible by 3")
             conv_weight = conv_weight.reshape(
                 out_channels,
                 in_channels // 3,
@@ -116,99 +120,19 @@ def adapt_input_conv(in_chans: int, conv_weight: torch.Tensor) -> torch.Tensor:
 
     return conv_weight
 
+def drop_path(x, drop_prob: float = 0.0, training: bool = False):
+    """
+    Apply stochastic depth (drop path) regularization.
 
-def load_pretrained_weights(
-    model: nn.Module,
-    first_conv: str | None = None,
-    pretrained_url: str | None = None,
-    filter_fn=None,
-    num_classes: int = 1000,
-    in_chans: int =3,
-    strict: bool = False,
-    progress: bool = False,
-    classifiers: tuple | None = None,
-    label_offset: int = 0
-):
-    """Load pretrained checkpoint
+    Randomly drops entire paths (residual blocks) during training to improve generalization.
 
     Args:
-        model (nn.Module) : PyTorch model module
-        default_cfg (Optional[Dict]): default configuration for pretrained weights / target dataset
-        num_classes (int): num_classes for model
-        in_chans (int): in_chans for model
-        filter_fn (Optional[Callable]): state_dict filter fn for load (takes state_dict, model as args)
-        strict (bool): strict load of checkpoint
-        progress (bool): enable progress bar for weight download
+        x (torch.Tensor): Input tensor.
+        drop_prob (float, optional): Probability of dropping a path. Defaults to 0.
+        training (bool, optional): Whether the model is in training mode. Defaults to False.
 
-    """
-    if not pretrained_url:
-        _logger.warning(
-            "No pretrained weights exist for this model. Using random initialization."
-        )
-        return
-
-    _logger.info(f"Loading pretrained weights from url ({pretrained_url})")
-    
-    pretrained_loc = download_cached_file(
-        pretrained_url,
-        check_hash=_CHECK_HASH,
-        progress=_DOWNLOAD_PROGRESS,
-    )
-
-    state_dict = torch.load(pretrained_loc, map_location="cpu")
-
-    if filter_fn is not None:
-        # for backwards compat with filter fn that take one arg, try one first, the two
-        try:
-            state_dict = filter_fn(state_dict)
-        except TypeError:
-            state_dict = filter_fn(state_dict, model)
-
-    input_convs = first_conv
-    if input_convs is not None and in_chans != 3:
-        if isinstance(input_convs, str):
-            input_convs = (input_convs,)
-        for input_conv_name in input_convs:
-            weight_name = input_conv_name + ".weight"
-            try:
-                state_dict[weight_name] = adapt_input_conv(
-                    in_chans, state_dict[weight_name]
-                )
-                _logger.info(
-                    f"Converted input conv {input_conv_name} pretrained weights from 3 to {in_chans} channel(s)"
-                )
-            except NotImplementedError:
-                del state_dict[weight_name]
-                strict = False
-                _logger.warning(
-                    f"Unable to convert pretrained {input_conv_name} weights, using random init for this layer."
-                )
-
-    if classifiers is not None:
-        if isinstance(classifiers, str):
-            classifiers = (classifiers,)
-
-        # Always drop classifier heads for backbone usage
-        for classifier_name in classifiers:
-            for suffix in ("weight", "bias"):
-                key = f"{classifier_name}.{suffix}"
-                if key in state_dict:
-                    del state_dict[key]
-
-        strict = False
-
-    model.load_state_dict(state_dict, strict=strict)
-
-
-def drop_path(x, drop_prob: float = 0.0, training: bool = False):
-    """Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
-
-    This is the same as the DropConnect impl I created for EfficientNet, etc networks, however,
-    the original name is misleading as 'Drop Connect' is a different form of dropout in a separate paper...
-    See discussion: https://github.com/tensorflow/tpu/issues/494#issuecomment-532968956 ... I've opted for
-    changing the layer and argument names to 'drop path' rather than mix DropConnect as a layer name and use
-    'survival rate' as the argument.
-
+    Returns:
+        torch.Tensor: Tensor with dropped paths applied.
     """
     if drop_prob == 0.0 or not training:
         return x
@@ -223,8 +147,20 @@ def drop_path(x, drop_prob: float = 0.0, training: bool = False):
 
 
 class DropPath(nn.Module):
-    """Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks)."""
+    """
+    Drop paths (stochastic depth) layer for residual networks.
 
+    This module wraps the `drop_path` function to be used as a standard nn.Module.
+
+    Args:
+        drop_prob (float, optional): Probability of dropping paths. Defaults to None.
+
+    Forward Args:
+        x (torch.Tensor): Input tensor.
+
+    Returns:
+        torch.Tensor: Tensor with stochastic depth applied.
+    """
     def __init__(self, drop_prob=None):
         super().__init__()
         self.drop_prob = drop_prob
@@ -233,18 +169,31 @@ class DropPath(nn.Module):
         return drop_path(x, self.drop_prob, self.training)
 
 def _no_grad_trunc_normal_(tensor, mean, std, a, b):
-    # Cut & paste from PyTorch official master until it's in a few official releases - RW
-    # Method based on https://people.sc.fsu.edu/~jburkardt/presentations/truncated_normal.pdf
-    def norm_cdf(x):
-        # Computes standard normal cumulative distribution function
-        return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
+    """
+    Fill a tensor with values from a truncated normal distribution in-place.
+    Values are clipped to [a, b].
 
-    if (mean < a - 2 * std) or (mean > b + 2 * std):
-        warnings.warn(
-            "mean is more than 2 std from [a, b] in nn.init.trunc_normal_. "
-            "The distribution of values may be incorrect.",
-            stacklevel=2,
-        )
+    Args:
+        tensor (torch.Tensor): Tensor to fill.
+        mean (float): Mean of the normal distribution.
+        std (float): Standard deviation.
+        a (float): Minimum cutoff value.
+        b (float): Maximum cutoff value.
+
+    Returns:
+        torch.Tensor: The same tensor filled in-place.
+    """
+    def norm_cdf(x):
+        """
+        Standard normal cumulative distribution function.
+
+        Args:
+            x (float or Tensor): Input value(s).
+
+        Returns:
+            float or Tensor: CDF evaluated at x.
+        """
+        return (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
 
     with torch.no_grad():
         # Values are generated by using a truncated uniform distribution and
@@ -271,26 +220,40 @@ def _no_grad_trunc_normal_(tensor, mean, std, a, b):
 
 
 def trunc_normal_(tensor, mean=0.0, std=1.0, a=-2.0, b=2.0):
-    r"""Fills the input Tensor with values drawn from a truncated
-    normal distribution. The values are effectively drawn from the
-    normal distribution :math:`\mathcal{N}(\text{mean}, \text{std}^2)`
-    with values outside :math:`[a, b]` redrawn until they are within
-    the bounds. The method used for generating the random values works
-    best when :math:`a \leq \text{mean} \leq b`.
+    """
+    Fill tensor with values drawn from a truncated normal distribution.
+
+    Values outside [a, b] are redrawn until they lie within bounds.
+
     Args:
-        tensor: an n-dimensional `torch.Tensor`
-        mean: the mean of the normal distribution
-        std: the standard deviation of the normal distribution
-        a: the minimum cutoff value
-        b: the maximum cutoff value
-    Examples:
-        >>> w = torch.empty(3, 5)
-        >>> nn.init.trunc_normal_(w)
+        tensor (torch.Tensor): Tensor to initialize.
+        mean (float, optional): Distribution mean. Defaults to 0.0.
+        std (float, optional): Distribution standard deviation. Defaults to 1.0.
+        a (float, optional): Minimum cutoff. Defaults to -2.0.
+        b (float, optional): Maximum cutoff. Defaults to 2.0.
+
+    Returns:
+        torch.Tensor: The same tensor initialized in-place.
     """
     return _no_grad_trunc_normal_(tensor, mean, std, a, b)
 
 
 def variance_scaling_(tensor, scale=1.0, mode="fan_in", distribution="normal"):
+    """
+    Initialize a tensor with variance scaling.
+
+    Supports normal, truncated normal, and uniform distributions.
+
+    Args:
+        tensor (torch.Tensor): Tensor to initialize.
+        scale (float, optional): Scaling factor. Defaults to 1.0.
+        mode (str, optional): One of ['fan_in', 'fan_out', 'fan_avg']. Defaults to 'fan_in'.
+        distribution (str, optional): Distribution type. One of ['normal', 'truncated_normal', 'uniform']. 
+                                        Defaults to 'normal'.
+
+    Raises:
+        ValueError: If `distribution` is invalid.
+    """
     fan_in, fan_out = _calculate_fan_in_and_fan_out(tensor)
     if mode == "fan_in":
         denom = fan_in
@@ -312,6 +275,11 @@ def variance_scaling_(tensor, scale=1.0, mode="fan_in", distribution="normal"):
     else:
         raise ValueError(f"invalid distribution {distribution}")
 
-
 def lecun_normal_(tensor):
+    """
+    Initialize a tensor with LeCun normal initialization (truncated normal).
+
+    Args:
+        tensor (torch.Tensor): Tensor to initialize.
+    """
     variance_scaling_(tensor, mode="fan_in", distribution="truncated_normal")

--- a/src/deepaudiox/modules/backbones/passt/vit_helpers.py
+++ b/src/deepaudiox/modules/backbones/passt/vit_helpers.py
@@ -156,9 +156,9 @@ class DropPath(nn.Module):
         torch.Tensor: Tensor with stochastic depth applied.
     """
 
-    def __init__(self, drop_prob=None):
+    def __init__(self, drop_prob: float | None = None):
         super().__init__()
-        self.drop_prob = drop_prob
+        self.drop_prob: float = 0.0 if drop_prob is None else drop_prob
 
     def forward(self, x):
         return drop_path(x, self.drop_prob, self.training)
@@ -258,6 +258,8 @@ def variance_scaling_(tensor, scale=1.0, mode="fan_in", distribution="normal"):
         denom = fan_out
     elif mode == "fan_avg":
         denom = (fan_in + fan_out) / 2
+    else:
+        raise ValueError(f"invalid mode {mode}")
 
     variance = scale / denom
 

--- a/src/deepaudiox/utils/downloader.py
+++ b/src/deepaudiox/utils/downloader.py
@@ -10,7 +10,7 @@ BACKBONE_REPO_URL = "https://github.com/magcil/pretrained-ssl-audio-backbones/ra
 
 BACKBONE_URLS = {
     "beats": BACKBONE_REPO_URL + "BEATs_iter3_plus_AS2M.pt",
-    "passt": BACKBONE_REPO_URL + "passt-s-kd-ap.486.pt"
+    "passt": BACKBONE_REPO_URL + "passt-s-kd-ap.486.pt",
 }
 
 
@@ -34,7 +34,7 @@ class Downloader:
         self.cache_dir = Path(user_cache_dir("deepaudiox"))
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def download_checkpoint(self, backbone: Literal["beats"]) -> Path:
+    def download_checkpoint(self, backbone: Literal["beats", "passt"]) -> Path:
         """Downloads the pretrained backbone weights if not already cached.
 
         Args:

--- a/src/deepaudiox/utils/downloader.py
+++ b/src/deepaudiox/utils/downloader.py
@@ -8,7 +8,10 @@ from tqdm import tqdm
 # Repository URL where the pretrained backbone models are hosted
 BACKBONE_REPO_URL = "https://github.com/magcil/pretrained-ssl-audio-backbones/raw/refs/heads/main/models/"
 
-BACKBONE_URLS = {"beats": BACKBONE_REPO_URL + "BEATs_iter3_plus_AS2M.pt"}
+BACKBONE_URLS = {
+    "beats": BACKBONE_REPO_URL + "BEATs_iter3_plus_AS2M.pt",
+    "passt": BACKBONE_REPO_URL + "passt-s-kd-ap.486.pt"
+}
 
 
 class Downloader:

--- a/tests/test_deepaudiox.py
+++ b/tests/test_deepaudiox.py
@@ -90,7 +90,11 @@ def test_dataset_loading_from_dict(file_to_class_mapping, sample_rate):
 
 def test_dataset_splitting():
     class_mapping = get_class_mapping_from_dir(str(TRAIN_DIR))
-    dataset = audio_classification_dataset_from_dir(root_dir=str(TRAIN_DIR), sample_rate=16000, class_mapping=class_mapping)
+    dataset = audio_classification_dataset_from_dir(
+        root_dir=str(TRAIN_DIR), 
+        sample_rate=16000, 
+        class_mapping=class_mapping
+    )
 
     train_dataset, validation_dataset = random_split_audio_dataset(dataset=dataset, train_ratio=0.8)
 

--- a/tests/test_deepaudiox.py
+++ b/tests/test_deepaudiox.py
@@ -121,6 +121,16 @@ def test_beats_backbone(input_tensor):
     assert output.shape == (1, 48, 768)
 
 
+@pytest.mark.parametrize("input_tensor", [torch.randn(1, 32000)])
+def test_passt_backbone(input_tensor):
+    passt = BACKBONES["passt"]()
+
+    output = passt.forward_pipeline(input_tensor)
+    print(output.shape)
+
+    assert output.shape == (1, 108, 768)
+
+
 @pytest.mark.parametrize("input_tensor", [torch.randn(1, 768)])
 @pytest.mark.parametrize("hidden_layers", [None, [128], [512, 128]])
 def test_mlp_head(input_tensor, hidden_layers):
@@ -132,7 +142,7 @@ def test_mlp_head(input_tensor, hidden_layers):
 
 @pytest.mark.parametrize("input_tensor", [torch.randn(1, 16000)])
 @pytest.mark.parametrize("num_classes", [2, 8])
-@pytest.mark.parametrize("backbone", ["beats"])
+@pytest.mark.parametrize("backbone", ["beats", "passt"])
 @pytest.mark.parametrize("pooling", ["simpool", "gap", "ep"])
 @pytest.mark.parametrize("freeze_backbone", [True, False])
 @pytest.mark.parametrize("pretrained", [True, False])

--- a/uv.lock
+++ b/uv.lock
@@ -8,19 +8,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "anyio"
-version = "4.12.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
-]
-
-[[package]]
 name = "audioop-lts"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -238,18 +225,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -276,7 +251,6 @@ dependencies = [
     { name = "numpy" },
     { name = "platformdirs" },
     { name = "soundfile" },
-    { name = "timm" },
     { name = "torch" },
     { name = "torchaudio" },
     { name = "tqdm" },
@@ -294,7 +268,6 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.3.3" },
     { name = "platformdirs", specifier = ">=4.5.0" },
     { name = "soundfile", specifier = ">=0.13.1" },
-    { name = "timm", specifier = ">=1.0.24" },
     { name = "torch", specifier = ">=2.8.0" },
     { name = "torchaudio", specifier = ">=2.8.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
@@ -322,93 +295,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
-]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "hf-xet"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/51/f7e2caae42f80af886db414d4e9885fac959330509089f97cccb339c6b87/hf_xet-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:10bfab528b968c70e062607f663e21e34e2bba349e8038db546646875495179e", size = 2861861, upload-time = "2025-10-24T19:04:19.01Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1d/a641a88b69994f9371bd347f1dd35e5d1e2e2460a2e350c8d5165fc62005/hf_xet-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2a212e842647b02eb6a911187dc878e79c4aa0aa397e88dd3b26761676e8c1f8", size = 2717699, upload-time = "2025-10-24T19:04:17.306Z" },
-    { url = "https://files.pythonhosted.org/packages/df/e0/e5e9bba7d15f0318955f7ec3f4af13f92e773fbb368c0b8008a5acbcb12f/hf_xet-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30e06daccb3a7d4c065f34fc26c14c74f4653069bb2b194e7f18f17cbe9939c0", size = 3314885, upload-time = "2025-10-24T19:04:07.642Z" },
-    { url = "https://files.pythonhosted.org/packages/21/90/b7fe5ff6f2b7b8cbdf1bd56145f863c90a5807d9758a549bf3d916aa4dec/hf_xet-1.2.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:29c8fc913a529ec0a91867ce3d119ac1aac966e098cf49501800c870328cc090", size = 3221550, upload-time = "2025-10-24T19:04:05.55Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/cb/73f276f0a7ce46cc6a6ec7d6c7d61cbfe5f2e107123d9bbd0193c355f106/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e159cbfcfbb29f920db2c09ed8b660eb894640d284f102ada929b6e3dc410a", size = 3408010, upload-time = "2025-10-24T19:04:28.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/1e/d642a12caa78171f4be64f7cd9c40e3ca5279d055d0873188a58c0f5fbb9/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c91d5ae931510107f148874e9e2de8a16052b6f1b3ca3c1b12f15ccb491390f", size = 3503264, upload-time = "2025-10-24T19:04:30.397Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b5/33764714923fa1ff922770f7ed18c2daae034d21ae6e10dbf4347c854154/hf_xet-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:210d577732b519ac6ede149d2f2f34049d44e8622bf14eb3d63bbcd2d4b332dc", size = 2901071, upload-time = "2025-10-24T19:04:37.463Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "huggingface-hub"
-version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "shellingham" },
-    { name = "tqdm" },
-    { name = "typer-slim" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/d6/02d1c505e1d3364230e5fa16d2b58c8f36a39c5efe8e99bc4d03d06fd0ca/huggingface_hub-1.3.2.tar.gz", hash = "sha256:15d7902e154f04174a0816d1e9594adcf15cdad57596920a5dc70fadb5d896c7", size = 624018, upload-time = "2026-01-14T13:57:39.635Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/1d/acd3ef8aabb7813c6ef2f91785d855583ac5cd7c3599e5c1a1a2ed1ec2e5/huggingface_hub-1.3.2-py3-none-any.whl", hash = "sha256:b552b9562a5532102a041fa31a6966bb9de95138fc7aa578bb3703198c25d1b6", size = 534504, upload-time = "2026-01-14T13:57:37.555Z" },
 ]
 
 [[package]]
@@ -874,93 +760,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pillow"
-version = "12.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/02/d52c733a2452ef1ffcc123b68e6606d07276b0e358db70eabad7e40042b7/pillow-12.1.0.tar.gz", hash = "sha256:5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9", size = 46977283, upload-time = "2026-01-02T09:13:29.892Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/c4/bf8328039de6cc22182c3ef007a2abfbbdab153661c0a9aa78af8d706391/pillow-12.1.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:a83e0850cb8f5ac975291ebfc4170ba481f41a28065277f7f735c202cd8e0af3", size = 5304057, upload-time = "2026-01-02T09:10:46.627Z" },
-    { url = "https://files.pythonhosted.org/packages/43/06/7264c0597e676104cc22ca73ee48f752767cd4b1fe084662620b17e10120/pillow-12.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b6e53e82ec2db0717eabb276aa56cf4e500c9a7cec2c2e189b55c24f65a3e8c0", size = 4657811, upload-time = "2026-01-02T09:10:49.548Z" },
-    { url = "https://files.pythonhosted.org/packages/72/64/f9189e44474610daf83da31145fa56710b627b5c4c0b9c235e34058f6b31/pillow-12.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:40a8e3b9e8773876d6e30daed22f016509e3987bab61b3b7fe309d7019a87451", size = 6232243, upload-time = "2026-01-02T09:10:51.62Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/30/0df458009be6a4caca4ca2c52975e6275c387d4e5c95544e34138b41dc86/pillow-12.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:800429ac32c9b72909c671aaf17ecd13110f823ddb7db4dfef412a5587c2c24e", size = 8037872, upload-time = "2026-01-02T09:10:53.446Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/86/95845d4eda4f4f9557e25381d70876aa213560243ac1a6d619c46caaedd9/pillow-12.1.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b022eaaf709541b391ee069f0022ee5b36c709df71986e3f7be312e46f42c84", size = 6345398, upload-time = "2026-01-02T09:10:55.426Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/1f/8e66ab9be3aaf1435bc03edd1ebdf58ffcd17f7349c1d970cafe87af27d9/pillow-12.1.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f345e7bc9d7f368887c712aa5054558bad44d2a301ddf9248599f4161abc7c0", size = 7034667, upload-time = "2026-01-02T09:10:57.11Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f6/683b83cb9b1db1fb52b87951b1c0b99bdcfceaa75febf11406c19f82cb5e/pillow-12.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d70347c8a5b7ccd803ec0c85c8709f036e6348f1e6a5bf048ecd9c64d3550b8b", size = 6458743, upload-time = "2026-01-02T09:10:59.331Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/7d/de833d63622538c1d58ce5395e7c6cb7e7dce80decdd8bde4a484e095d9f/pillow-12.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1fcc52d86ce7a34fd17cb04e87cfdb164648a3662a6f20565910a99653d66c18", size = 7159342, upload-time = "2026-01-02T09:11:01.82Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/40/50d86571c9e5868c42b81fe7da0c76ca26373f3b95a8dd675425f4a92ec1/pillow-12.1.0-cp311-cp311-win32.whl", hash = "sha256:3ffaa2f0659e2f740473bcf03c702c39a8d4b2b7ffc629052028764324842c64", size = 6328655, upload-time = "2026-01-02T09:11:04.556Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/af/b1d7e301c4cd26cd45d4af884d9ee9b6fab893b0ad2450d4746d74a6968c/pillow-12.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:806f3987ffe10e867bab0ddad45df1148a2b98221798457fa097ad85d6e8bc75", size = 7031469, upload-time = "2026-01-02T09:11:06.538Z" },
-    { url = "https://files.pythonhosted.org/packages/48/36/d5716586d887fb2a810a4a61518a327a1e21c8b7134c89283af272efe84b/pillow-12.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:9f5fefaca968e700ad1a4a9de98bf0869a94e397fe3524c4c9450c1445252304", size = 2452515, upload-time = "2026-01-02T09:11:08.226Z" },
-    { url = "https://files.pythonhosted.org/packages/20/31/dc53fe21a2f2996e1b7d92bf671cdb157079385183ef7c1ae08b485db510/pillow-12.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a332ac4ccb84b6dde65dbace8431f3af08874bf9770719d32a635c4ef411b18b", size = 5262642, upload-time = "2026-01-02T09:11:10.138Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c1/10e45ac9cc79419cedf5121b42dcca5a50ad2b601fa080f58c22fb27626e/pillow-12.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:907bfa8a9cb790748a9aa4513e37c88c59660da3bcfffbd24a7d9e6abf224551", size = 4657464, upload-time = "2026-01-02T09:11:12.319Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/26/7b82c0ab7ef40ebede7a97c72d473bda5950f609f8e0c77b04af574a0ddb/pillow-12.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:efdc140e7b63b8f739d09a99033aa430accce485ff78e6d311973a67b6bf3208", size = 6234878, upload-time = "2026-01-02T09:11:14.096Z" },
-    { url = "https://files.pythonhosted.org/packages/76/25/27abc9792615b5e886ca9411ba6637b675f1b77af3104710ac7353fe5605/pillow-12.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bef9768cab184e7ae6e559c032e95ba8d07b3023c289f79a2bd36e8bf85605a5", size = 8044868, upload-time = "2026-01-02T09:11:15.903Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/ea/f200a4c36d836100e7bc738fc48cd963d3ba6372ebc8298a889e0cfc3359/pillow-12.1.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:742aea052cf5ab5034a53c3846165bc3ce88d7c38e954120db0ab867ca242661", size = 6349468, upload-time = "2026-01-02T09:11:17.631Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8f/48d0b77ab2200374c66d344459b8958c86693be99526450e7aee714e03e4/pillow-12.1.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6dfc2af5b082b635af6e08e0d1f9f1c4e04d17d4e2ca0ef96131e85eda6eb17", size = 7041518, upload-time = "2026-01-02T09:11:19.389Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/23/c281182eb986b5d31f0a76d2a2c8cd41722d6fb8ed07521e802f9bba52de/pillow-12.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:609e89d9f90b581c8d16358c9087df76024cf058fa693dd3e1e1620823f39670", size = 6462829, upload-time = "2026-01-02T09:11:21.28Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ef/7018273e0faac099d7b00982abdcc39142ae6f3bd9ceb06de09779c4a9d6/pillow-12.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43b4899cfd091a9693a1278c4982f3e50f7fb7cff5153b05174b4afc9593b616", size = 7166756, upload-time = "2026-01-02T09:11:23.559Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/c8/993d4b7ab2e341fe02ceef9576afcf5830cdec640be2ac5bee1820d693d4/pillow-12.1.0-cp312-cp312-win32.whl", hash = "sha256:aa0c9cc0b82b14766a99fbe6084409972266e82f459821cd26997a488a7261a7", size = 6328770, upload-time = "2026-01-02T09:11:25.661Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/87/90b358775a3f02765d87655237229ba64a997b87efa8ccaca7dd3e36e7a7/pillow-12.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:d70534cea9e7966169ad29a903b99fc507e932069a881d0965a1a84bb57f6c6d", size = 7033406, upload-time = "2026-01-02T09:11:27.474Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/cf/881b457eccacac9e5b2ddd97d5071fb6d668307c57cbf4e3b5278e06e536/pillow-12.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:65b80c1ee7e14a87d6a068dd3b0aea268ffcabfe0498d38661b00c5b4b22e74c", size = 2452612, upload-time = "2026-01-02T09:11:29.309Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/c7/2530a4aa28248623e9d7f27316b42e27c32ec410f695929696f2e0e4a778/pillow-12.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7b5dd7cbae20285cdb597b10eb5a2c13aa9de6cde9bb64a3c1317427b1db1ae1", size = 4062543, upload-time = "2026-01-02T09:11:31.566Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/1f/40b8eae823dc1519b87d53c30ed9ef085506b05281d313031755c1705f73/pillow-12.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:29a4cef9cb672363926f0470afc516dbf7305a14d8c54f7abbb5c199cd8f8179", size = 4138373, upload-time = "2026-01-02T09:11:33.367Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/77/6fa60634cf06e52139fd0e89e5bbf055e8166c691c42fb162818b7fda31d/pillow-12.1.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:681088909d7e8fa9e31b9799aaa59ba5234c58e5e4f1951b4c4d1082a2e980e0", size = 3601241, upload-time = "2026-01-02T09:11:35.011Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/bf/28ab865de622e14b747f0cd7877510848252d950e43002e224fb1c9ababf/pillow-12.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:983976c2ab753166dc66d36af6e8ec15bb511e4a25856e2227e5f7e00a160587", size = 5262410, upload-time = "2026-01-02T09:11:36.682Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/34/583420a1b55e715937a85bd48c5c0991598247a1fd2eb5423188e765ea02/pillow-12.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:db44d5c160a90df2d24a24760bbd37607d53da0b34fb546c4c232af7192298ac", size = 4657312, upload-time = "2026-01-02T09:11:38.535Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/fd/f5a0896839762885b3376ff04878f86ab2b097c2f9a9cdccf4eda8ba8dc0/pillow-12.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6b7a9d1db5dad90e2991645874f708e87d9a3c370c243c2d7684d28f7e133e6b", size = 6232605, upload-time = "2026-01-02T09:11:40.602Z" },
-    { url = "https://files.pythonhosted.org/packages/98/aa/938a09d127ac1e70e6ed467bd03834350b33ef646b31edb7452d5de43792/pillow-12.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6258f3260986990ba2fa8a874f8b6e808cf5abb51a94015ca3dc3c68aa4f30ea", size = 8041617, upload-time = "2026-01-02T09:11:42.721Z" },
-    { url = "https://files.pythonhosted.org/packages/17/e8/538b24cb426ac0186e03f80f78bc8dc7246c667f58b540bdd57c71c9f79d/pillow-12.1.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e115c15e3bc727b1ca3e641a909f77f8ca72a64fff150f666fcc85e57701c26c", size = 6346509, upload-time = "2026-01-02T09:11:44.955Z" },
-    { url = "https://files.pythonhosted.org/packages/01/9a/632e58ec89a32738cabfd9ec418f0e9898a2b4719afc581f07c04a05e3c9/pillow-12.1.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6741e6f3074a35e47c77b23a4e4f2d90db3ed905cb1c5e6e0d49bff2045632bc", size = 7038117, upload-time = "2026-01-02T09:11:46.736Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/a2/d40308cf86eada842ca1f3ffa45d0ca0df7e4ab33c83f81e73f5eaed136d/pillow-12.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:935b9d1aed48fcfb3f838caac506f38e29621b44ccc4f8a64d575cb1b2a88644", size = 6460151, upload-time = "2026-01-02T09:11:48.625Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/88/f5b058ad6453a085c5266660a1417bdad590199da1b32fb4efcff9d33b05/pillow-12.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5fee4c04aad8932da9f8f710af2c1a15a83582cfb884152a9caa79d4efcdbf9c", size = 7164534, upload-time = "2026-01-02T09:11:50.445Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ce/c17334caea1db789163b5d855a5735e47995b0b5dc8745e9a3605d5f24c0/pillow-12.1.0-cp313-cp313-win32.whl", hash = "sha256:a786bf667724d84aa29b5db1c61b7bfdde380202aaca12c3461afd6b71743171", size = 6332551, upload-time = "2026-01-02T09:11:52.234Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/07/74a9d941fa45c90a0d9465098fe1ec85de3e2afbdc15cc4766622d516056/pillow-12.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:461f9dfdafa394c59cd6d818bdfdbab4028b83b02caadaff0ffd433faf4c9a7a", size = 7040087, upload-time = "2026-01-02T09:11:54.822Z" },
-    { url = "https://files.pythonhosted.org/packages/88/09/c99950c075a0e9053d8e880595926302575bc742b1b47fe1bbcc8d388d50/pillow-12.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:9212d6b86917a2300669511ed094a9406888362e085f2431a7da985a6b124f45", size = 2452470, upload-time = "2026-01-02T09:11:56.522Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/ba/970b7d85ba01f348dee4d65412476321d40ee04dcb51cd3735b9dc94eb58/pillow-12.1.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:00162e9ca6d22b7c3ee8e61faa3c3253cd19b6a37f126cad04f2f88b306f557d", size = 5264816, upload-time = "2026-01-02T09:11:58.227Z" },
-    { url = "https://files.pythonhosted.org/packages/10/60/650f2fb55fdba7a510d836202aa52f0baac633e50ab1cf18415d332188fb/pillow-12.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7d6daa89a00b58c37cb1747ec9fb7ac3bc5ffd5949f5888657dfddde6d1312e0", size = 4660472, upload-time = "2026-01-02T09:12:00.798Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/5273a99478956a099d533c4f46cbaa19fd69d606624f4334b85e50987a08/pillow-12.1.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2479c7f02f9d505682dc47df8c0ea1fc5e264c4d1629a5d63fe3e2334b89554", size = 6268974, upload-time = "2026-01-02T09:12:02.572Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/26/0bf714bc2e73d5267887d47931d53c4ceeceea6978148ed2ab2a4e6463c4/pillow-12.1.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f188d580bd870cda1e15183790d1cc2fa78f666e76077d103edf048eed9c356e", size = 8073070, upload-time = "2026-01-02T09:12:04.75Z" },
-    { url = "https://files.pythonhosted.org/packages/43/cf/1ea826200de111a9d65724c54f927f3111dc5ae297f294b370a670c17786/pillow-12.1.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0fde7ec5538ab5095cc02df38ee99b0443ff0e1c847a045554cf5f9af1f4aa82", size = 6380176, upload-time = "2026-01-02T09:12:06.626Z" },
-    { url = "https://files.pythonhosted.org/packages/03/e0/7938dd2b2013373fd85d96e0f38d62b7a5a262af21ac274250c7ca7847c9/pillow-12.1.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ed07dca4a8464bada6139ab38f5382f83e5f111698caf3191cb8dbf27d908b4", size = 7067061, upload-time = "2026-01-02T09:12:08.624Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ad/a2aa97d37272a929a98437a8c0ac37b3cf012f4f8721e1bd5154699b2518/pillow-12.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f45bd71d1fa5e5749587613037b172e0b3b23159d1c00ef2fc920da6f470e6f0", size = 6491824, upload-time = "2026-01-02T09:12:10.488Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/44/80e46611b288d51b115826f136fb3465653c28f491068a72d3da49b54cd4/pillow-12.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:277518bf4fe74aa91489e1b20577473b19ee70fb97c374aa50830b279f25841b", size = 7190911, upload-time = "2026-01-02T09:12:12.772Z" },
-    { url = "https://files.pythonhosted.org/packages/86/77/eacc62356b4cf81abe99ff9dbc7402750044aed02cfd6a503f7c6fc11f3e/pillow-12.1.0-cp313-cp313t-win32.whl", hash = "sha256:7315f9137087c4e0ee73a761b163fc9aa3b19f5f606a7fc08d83fd3e4379af65", size = 6336445, upload-time = "2026-01-02T09:12:14.775Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3c/57d81d0b74d218706dafccb87a87ea44262c43eef98eb3b164fd000e0491/pillow-12.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:0ddedfaa8b5f0b4ffbc2fa87b556dc59f6bb4ecb14a53b33f9189713ae8053c0", size = 7045354, upload-time = "2026-01-02T09:12:16.599Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/82/8b9b97bba2e3576a340f93b044a3a3a09841170ab4c1eb0d5c93469fd32f/pillow-12.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:80941e6d573197a0c28f394753de529bb436b1ca990ed6e765cf42426abc39f8", size = 2454547, upload-time = "2026-01-02T09:12:18.704Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/87/bdf971d8bbcf80a348cc3bacfcb239f5882100fe80534b0ce67a784181d8/pillow-12.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:5cb7bc1966d031aec37ddb9dcf15c2da5b2e9f7cc3ca7c54473a20a927e1eb91", size = 4062533, upload-time = "2026-01-02T09:12:20.791Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/4f/5eb37a681c68d605eb7034c004875c81f86ec9ef51f5be4a63eadd58859a/pillow-12.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:97e9993d5ed946aba26baf9c1e8cf18adbab584b99f452ee72f7ee8acb882796", size = 4138546, upload-time = "2026-01-02T09:12:23.664Z" },
-    { url = "https://files.pythonhosted.org/packages/11/6d/19a95acb2edbace40dcd582d077b991646b7083c41b98da4ed7555b59733/pillow-12.1.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:414b9a78e14ffeb98128863314e62c3f24b8a86081066625700b7985b3f529bd", size = 3601163, upload-time = "2026-01-02T09:12:26.338Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/36/2b8138e51cb42e4cc39c3297713455548be855a50558c3ac2beebdc251dd/pillow-12.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e6bdb408f7c9dd2a5ff2b14a3b0bb6d4deb29fb9961e6eb3ae2031ae9a5cec13", size = 5266086, upload-time = "2026-01-02T09:12:28.782Z" },
-    { url = "https://files.pythonhosted.org/packages/53/4b/649056e4d22e1caa90816bf99cef0884aed607ed38075bd75f091a607a38/pillow-12.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3413c2ae377550f5487991d444428f1a8ae92784aac79caa8b1e3b89b175f77e", size = 4657344, upload-time = "2026-01-02T09:12:31.117Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/6b/c5742cea0f1ade0cd61485dc3d81f05261fc2276f537fbdc00802de56779/pillow-12.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e5dcbe95016e88437ecf33544ba5db21ef1b8dd6e1b434a2cb2a3d605299e643", size = 6232114, upload-time = "2026-01-02T09:12:32.936Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/8f/9f521268ce22d63991601aafd3d48d5ff7280a246a1ef62d626d67b44064/pillow-12.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d0a7735df32ccbcc98b98a1ac785cc4b19b580be1bdf0aeb5c03223220ea09d5", size = 8042708, upload-time = "2026-01-02T09:12:34.78Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/eb/257f38542893f021502a1bbe0c2e883c90b5cff26cc33b1584a841a06d30/pillow-12.1.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c27407a2d1b96774cbc4a7594129cc027339fd800cd081e44497722ea1179de", size = 6347762, upload-time = "2026-01-02T09:12:36.748Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5a/8ba375025701c09b309e8d5163c5a4ce0102fa86bbf8800eb0d7ac87bc51/pillow-12.1.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15c794d74303828eaa957ff8070846d0efe8c630901a1c753fdc63850e19ecd9", size = 7039265, upload-time = "2026-01-02T09:12:39.082Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/dc/cf5e4cdb3db533f539e88a7bbf9f190c64ab8a08a9bc7a4ccf55067872e4/pillow-12.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c990547452ee2800d8506c4150280757f88532f3de2a58e3022e9b179107862a", size = 6462341, upload-time = "2026-01-02T09:12:40.946Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/47/0291a25ac9550677e22eda48510cfc4fa4b2ef0396448b7fbdc0a6946309/pillow-12.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b63e13dd27da389ed9475b3d28510f0f954bca0041e8e551b2a4eb1eab56a39a", size = 7165395, upload-time = "2026-01-02T09:12:42.706Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/4c/e005a59393ec4d9416be06e6b45820403bb946a778e39ecec62f5b2b991e/pillow-12.1.0-cp314-cp314-win32.whl", hash = "sha256:1a949604f73eb07a8adab38c4fe50791f9919344398bdc8ac6b307f755fc7030", size = 6431413, upload-time = "2026-01-02T09:12:44.944Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/af/f23697f587ac5f9095d67e31b81c95c0249cd461a9798a061ed6709b09b5/pillow-12.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f9f6a650743f0ddee5593ac9e954ba1bdbc5e150bc066586d4f26127853ab94", size = 7176779, upload-time = "2026-01-02T09:12:46.727Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/36/6a51abf8599232f3e9afbd16d52829376a68909fe14efe29084445db4b73/pillow-12.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:808b99604f7873c800c4840f55ff389936ef1948e4e87645eaf3fccbc8477ac4", size = 2543105, upload-time = "2026-01-02T09:12:49.243Z" },
-    { url = "https://files.pythonhosted.org/packages/82/54/2e1dd20c8749ff225080d6ba465a0cab4387f5db0d1c5fb1439e2d99923f/pillow-12.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc11908616c8a283cf7d664f77411a5ed2a02009b0097ff8abbba5e79128ccf2", size = 5268571, upload-time = "2026-01-02T09:12:51.11Z" },
-    { url = "https://files.pythonhosted.org/packages/57/61/571163a5ef86ec0cf30d265ac2a70ae6fc9e28413d1dc94fa37fae6bda89/pillow-12.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:896866d2d436563fa2a43a9d72f417874f16b5545955c54a64941e87c1376c61", size = 4660426, upload-time = "2026-01-02T09:12:52.865Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e1/53ee5163f794aef1bf84243f755ee6897a92c708505350dd1923f4afec48/pillow-12.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8e178e3e99d3c0ea8fc64b88447f7cac8ccf058af422a6cedc690d0eadd98c51", size = 6269908, upload-time = "2026-01-02T09:12:54.884Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/0b/b4b4106ff0ee1afa1dc599fde6ab230417f800279745124f6c50bcffed8e/pillow-12.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:079af2fb0c599c2ec144ba2c02766d1b55498e373b3ac64687e43849fbbef5bc", size = 8074733, upload-time = "2026-01-02T09:12:56.802Z" },
-    { url = "https://files.pythonhosted.org/packages/19/9f/80b411cbac4a732439e629a26ad3ef11907a8c7fc5377b7602f04f6fe4e7/pillow-12.1.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdec5e43377761c5dbca620efb69a77f6855c5a379e32ac5b158f54c84212b14", size = 6381431, upload-time = "2026-01-02T09:12:58.823Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b7/d65c45db463b66ecb6abc17c6ba6917a911202a07662247e1355ce1789e7/pillow-12.1.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:565c986f4b45c020f5421a4cea13ef294dde9509a8577f29b2fc5edc7587fff8", size = 7068529, upload-time = "2026-01-02T09:13:00.885Z" },
-    { url = "https://files.pythonhosted.org/packages/50/96/dfd4cd726b4a45ae6e3c669fc9e49deb2241312605d33aba50499e9d9bd1/pillow-12.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:43aca0a55ce1eefc0aefa6253661cb54571857b1a7b2964bd8a1e3ef4b729924", size = 6492981, upload-time = "2026-01-02T09:13:03.314Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/1c/b5dc52cf713ae46033359c5ca920444f18a6359ce1020dd3e9c553ea5bc6/pillow-12.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0deedf2ea233722476b3a81e8cdfbad786f7adbed5d848469fa59fe52396e4ef", size = 7191878, upload-time = "2026-01-02T09:13:05.276Z" },
-    { url = "https://files.pythonhosted.org/packages/53/26/c4188248bd5edaf543864fe4834aebe9c9cb4968b6f573ce014cc42d0720/pillow-12.1.0-cp314-cp314t-win32.whl", hash = "sha256:b17fbdbe01c196e7e159aacb889e091f28e61020a8abeac07b68079b6e626988", size = 6438703, upload-time = "2026-01-02T09:13:07.491Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/0e/69ed296de8ea05cb03ee139cee600f424ca166e632567b2d66727f08c7ed/pillow-12.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27b9baecb428899db6c0de572d6d305cfaf38ca1596b5c0542a5182e3e74e8c6", size = 7182927, upload-time = "2026-01-02T09:13:09.841Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/f5/68334c015eed9b5cff77814258717dec591ded209ab5b6fb70e2ae873d1d/pillow-12.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f61333d817698bdcdd0f9d7793e365ac3d2a21c1f1eb02b32ad6aefb8d8ea831", size = 2545104, upload-time = "2026-01-02T09:13:12.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/bc/224b1d98cffd7164b14707c91aac83c07b047fbd8f58eba4066a3e53746a/pillow-12.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ca94b6aac0d7af2a10ba08c0f888b3d5114439b6b3ef39968378723622fed377", size = 5228605, upload-time = "2026-01-02T09:13:14.084Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ca/49ca7769c4550107de049ed85208240ba0f330b3f2e316f24534795702ce/pillow-12.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:351889afef0f485b84078ea40fe33727a0492b9af3904661b0abbafee0355b72", size = 4622245, upload-time = "2026-01-02T09:13:15.964Z" },
-    { url = "https://files.pythonhosted.org/packages/73/48/fac807ce82e5955bcc2718642b94b1bd22a82a6d452aea31cbb678cddf12/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb0984b30e973f7e2884362b7d23d0a348c7143ee559f38ef3eaab640144204c", size = 5247593, upload-time = "2026-01-02T09:13:17.913Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/95/3e0742fe358c4664aed4fd05d5f5373dcdad0b27af52aa0972568541e3f4/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:84cabc7095dd535ca934d57e9ce2a72ffd216e435a84acb06b2277b1de2689bd", size = 6989008, upload-time = "2026-01-02T09:13:20.083Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/74/fe2ac378e4e202e56d50540d92e1ef4ff34ed687f3c60f6a121bcf99437e/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53d8b764726d3af1a138dd353116f774e3862ec7e3794e0c8781e30db0f35dfc", size = 5313824, upload-time = "2026-01-02T09:13:22.405Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/77/2a60dee1adee4e2655ac328dd05c02a955c1cd683b9f1b82ec3feb44727c/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5da841d81b1a05ef940a8567da92decaa15bc4d7dedb540a8c219ad83d91808a", size = 5963278, upload-time = "2026-01-02T09:13:24.706Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/71/64e9b1c7f04ae0027f788a248e6297d7fcc29571371fe7d45495a78172c0/pillow-12.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:75af0b4c229ac519b155028fa1be632d812a519abba9b46b20e50c6caa184f19", size = 7029809, upload-time = "2026-01-02T09:13:26.541Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,61 +826,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyyaml"
-version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
-    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
-    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
-    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
-    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1120,28 +864,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/54/6177a0dc10bce6f43e392a2192e6018755473283d0cf43cc7e6afc182aea/ruff-0.13.1-py3-none-win32.whl", hash = "sha256:55e9efa692d7cb18580279f1fbb525146adc401f40735edf0aaeabd93099f9a0", size = 12178448, upload-time = "2025-09-18T19:52:35.545Z" },
     { url = "https://files.pythonhosted.org/packages/64/51/c6a3a33d9938007b8bdc8ca852ecc8d810a407fb513ab08e34af12dc7c24/ruff-0.13.1-py3-none-win_amd64.whl", hash = "sha256:3a3fb595287ee556de947183489f636b9f76a72f0fa9c028bdcabf5bab2cc5e5", size = 13286458, upload-time = "2025-09-18T19:52:38.198Z" },
     { url = "https://files.pythonhosted.org/packages/fd/04/afc078a12cf68592345b1e2d6ecdff837d286bac023d7a22c54c7a698c5b/ruff-0.13.1-py3-none-win_arm64.whl", hash = "sha256:c0bae9ffd92d54e03c2bf266f466da0a65e145f298ee5b5846ed435f6a00518a", size = 12437893, upload-time = "2025-09-18T19:52:41.283Z" },
-]
-
-[[package]]
-name = "safetensors"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
-    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
-    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
-    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
-    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
 ]
 
 [[package]]
@@ -1264,15 +986,6 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "soundfile"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1373,22 +1086,6 @@ wheels = [
 ]
 
 [[package]]
-name = "timm"
-version = "1.0.24"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "huggingface-hub" },
-    { name = "pyyaml" },
-    { name = "safetensors" },
-    { name = "torch" },
-    { name = "torchvision" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/9d/0ea45640be447445c8664ce2b10c74f763b0b0b9ed11620d41a4d4baa10c/timm-1.0.24.tar.gz", hash = "sha256:c7b909f43fe2ef8fe62c505e270cd4f1af230dfbc37f2ee93e3608492b9d9a40", size = 2412239, upload-time = "2026-01-07T00:26:17.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/dd/c1f5b0890f7b5db661bde0864b41cb0275be76851047e5f7e085fe0b455a/timm-1.0.24-py3-none-any.whl", hash = "sha256:8301ac783410c6ad72c73c49326af6d71a9e4d1558238552796e825c2464913f", size = 2560563, upload-time = "2026-01-07T00:26:13.956Z" },
-]
-
-[[package]]
 name = "torch"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1462,34 +1159,6 @@ wheels = [
 ]
 
 [[package]]
-name = "torchvision"
-version = "0.23.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/d7/15d3d7bd8d0239211b21673d1bac7bc345a4ad904a8e25bb3fd8a9cf1fbc/torchvision-0.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:49aa20e21f0c2bd458c71d7b449776cbd5f16693dd5807195a820612b8a229b7", size = 1856884, upload-time = "2025-08-06T14:58:00.237Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/14/7b44fe766b7d11e064c539d92a172fa9689a53b69029e24f2f1f51e7dc56/torchvision-0.23.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:01dc33ee24c79148aee7cdbcf34ae8a3c9da1674a591e781577b716d233b1fa6", size = 2395543, upload-time = "2025-08-06T14:58:04.373Z" },
-    { url = "https://files.pythonhosted.org/packages/79/9c/fcb09aff941c8147d9e6aa6c8f67412a05622b0c750bcf796be4c85a58d4/torchvision-0.23.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:35c27941831b653f5101edfe62c03d196c13f32139310519e8228f35eae0e96a", size = 8628388, upload-time = "2025-08-06T14:58:07.802Z" },
-    { url = "https://files.pythonhosted.org/packages/93/40/3415d890eb357b25a8e0a215d32365a88ecc75a283f75c4e919024b22d97/torchvision-0.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:09bfde260e7963a15b80c9e442faa9f021c7e7f877ac0a36ca6561b367185013", size = 1600741, upload-time = "2025-08-06T14:57:59.158Z" },
-    { url = "https://files.pythonhosted.org/packages/df/1d/0ea0b34bde92a86d42620f29baa6dcbb5c2fc85990316df5cb8f7abb8ea2/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440", size = 1856885, upload-time = "2025-08-06T14:58:06.503Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/00/2f6454decc0cd67158c7890364e446aad4b91797087a57a78e72e1a8f8bc/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948", size = 2396614, upload-time = "2025-08-06T14:58:03.116Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b5/3e580dcbc16f39a324f3dd71b90edbf02a42548ad44d2b4893cc92b1194b/torchvision-0.23.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4e7d31c43bc7cbecbb1a5652ac0106b436aa66e26437585fc2c4b2cf04d6014c", size = 8627108, upload-time = "2025-08-06T14:58:12.956Z" },
-    { url = "https://files.pythonhosted.org/packages/82/c1/c2fe6d61e110a8d0de2f94276899a2324a8f1e6aee559eb6b4629ab27466/torchvision-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2e45272abe7b8bf0d06c405e78521b5757be1bd0ed7e5cd78120f7fdd4cbf35", size = 1600723, upload-time = "2025-08-06T14:57:57.986Z" },
-    { url = "https://files.pythonhosted.org/packages/91/37/45a5b9407a7900f71d61b2b2f62db4b7c632debca397f205fdcacb502780/torchvision-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c37e325e09a184b730c3ef51424f383ec5745378dc0eca244520aca29722600", size = 1856886, upload-time = "2025-08-06T14:58:05.491Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/da/a06c60fc84fc849377cf035d3b3e9a1c896d52dbad493b963c0f1cdd74d0/torchvision-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2f7fd6c15f3697e80627b77934f77705f3bc0e98278b989b2655de01f6903e1d", size = 2353112, upload-time = "2025-08-06T14:58:26.265Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/27/5ce65ba5c9d3b7d2ccdd79892ab86a2f87ac2ca6638f04bb0280321f1a9c/torchvision-0.23.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a76fafe113b2977be3a21bf78f115438c1f88631d7a87203acb3dd6ae55889e6", size = 8627658, upload-time = "2025-08-06T14:58:15.999Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e4/028a27b60aa578a2fa99d9d7334ff1871bb17008693ea055a2fdee96da0d/torchvision-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:07d069cb29691ff566e3b7f11f20d91044f079e1dbdc9d72e0655899a9b06938", size = 1600749, upload-time = "2025-08-06T14:58:10.719Z" },
-    { url = "https://files.pythonhosted.org/packages/05/35/72f91ad9ac7c19a849dedf083d347dc1123f0adeb401f53974f84f1d04c8/torchvision-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:2df618e1143805a7673aaf82cb5720dd9112d4e771983156aaf2ffff692eebf9", size = 2047192, upload-time = "2025-08-06T14:58:11.813Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/9d/406cea60a9eb9882145bcd62a184ee61e823e8e1d550cdc3c3ea866a9445/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a3299d2b1d5a7aed2d3b6ffb69c672ca8830671967eb1cee1497bacd82fe47b", size = 2359295, upload-time = "2025-08-06T14:58:17.469Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f4/34662f71a70fa1e59de99772142f22257ca750de05ccb400b8d2e3809c1d/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:76bc4c0b63d5114aa81281390f8472a12a6a35ce9906e67ea6044e5af4cab60c", size = 8800474, upload-time = "2025-08-06T14:58:22.53Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/b5a2d841a8d228b5dbda6d524704408e19e7ca6b7bb0f24490e081da1fa1/torchvision-0.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b9e2dabf0da9c8aa9ea241afb63a8f3e98489e706b22ac3f30416a1be377153b", size = 1527667, upload-time = "2025-08-06T14:58:14.446Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1513,19 +1182,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
     { url = "https://files.pythonhosted.org/packages/20/63/8cb444ad5cdb25d999b7d647abac25af0ee37d292afc009940c05b82dda0/triton-3.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7936b18a3499ed62059414d7df563e6c163c5e16c3773678a3ee3d417865035d", size = 155659780, upload-time = "2025-07-30T19:58:51.171Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.21.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/17/d4/064570dec6358aa9049d4708e4a10407d74c99258f8b2136bb8702303f1a/typer_slim-0.21.1.tar.gz", hash = "sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd", size = 110478, upload-time = "2026-01-06T11:21:11.176Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/0a/4aca634faf693e33004796b6cee0ae2e1dba375a800c16ab8d3eff4bb800/typer_slim-0.21.1-py3-none-any.whl", hash = "sha256:6e6c31047f171ac93cc5a973c9e617dbc5ab2bddc4d0a3135dc161b4e2020e0d", size = 47444, upload-time = "2026-01-06T11:21:12.441Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,19 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "audioop-lts"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -225,6 +238,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -244,13 +269,14 @@ wheels = [
 
 [[package]]
 name = "deepaudio-x"
-version = "0.1.3"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "librosa" },
     { name = "numpy" },
     { name = "platformdirs" },
     { name = "soundfile" },
+    { name = "timm" },
     { name = "torch" },
     { name = "torchaudio" },
     { name = "tqdm" },
@@ -268,6 +294,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.3.3" },
     { name = "platformdirs", specifier = ">=4.5.0" },
     { name = "soundfile", specifier = ">=0.13.1" },
+    { name = "timm", specifier = ">=1.0.24" },
     { name = "torch", specifier = ">=2.8.0" },
     { name = "torchaudio", specifier = ">=2.8.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
@@ -295,6 +322,93 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/51/f7e2caae42f80af886db414d4e9885fac959330509089f97cccb339c6b87/hf_xet-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:10bfab528b968c70e062607f663e21e34e2bba349e8038db546646875495179e", size = 2861861, upload-time = "2025-10-24T19:04:19.01Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/1d/a641a88b69994f9371bd347f1dd35e5d1e2e2460a2e350c8d5165fc62005/hf_xet-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2a212e842647b02eb6a911187dc878e79c4aa0aa397e88dd3b26761676e8c1f8", size = 2717699, upload-time = "2025-10-24T19:04:17.306Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e0/e5e9bba7d15f0318955f7ec3f4af13f92e773fbb368c0b8008a5acbcb12f/hf_xet-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30e06daccb3a7d4c065f34fc26c14c74f4653069bb2b194e7f18f17cbe9939c0", size = 3314885, upload-time = "2025-10-24T19:04:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/21/90/b7fe5ff6f2b7b8cbdf1bd56145f863c90a5807d9758a549bf3d916aa4dec/hf_xet-1.2.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:29c8fc913a529ec0a91867ce3d119ac1aac966e098cf49501800c870328cc090", size = 3221550, upload-time = "2025-10-24T19:04:05.55Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/cb/73f276f0a7ce46cc6a6ec7d6c7d61cbfe5f2e107123d9bbd0193c355f106/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e159cbfcfbb29f920db2c09ed8b660eb894640d284f102ada929b6e3dc410a", size = 3408010, upload-time = "2025-10-24T19:04:28.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1e/d642a12caa78171f4be64f7cd9c40e3ca5279d055d0873188a58c0f5fbb9/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c91d5ae931510107f148874e9e2de8a16052b6f1b3ca3c1b12f15ccb491390f", size = 3503264, upload-time = "2025-10-24T19:04:30.397Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b5/33764714923fa1ff922770f7ed18c2daae034d21ae6e10dbf4347c854154/hf_xet-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:210d577732b519ac6ede149d2f2f34049d44e8622bf14eb3d63bbcd2d4b332dc", size = 2901071, upload-time = "2025-10-24T19:04:37.463Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
+    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
+    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "shellingham" },
+    { name = "tqdm" },
+    { name = "typer-slim" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/d6/02d1c505e1d3364230e5fa16d2b58c8f36a39c5efe8e99bc4d03d06fd0ca/huggingface_hub-1.3.2.tar.gz", hash = "sha256:15d7902e154f04174a0816d1e9594adcf15cdad57596920a5dc70fadb5d896c7", size = 624018, upload-time = "2026-01-14T13:57:39.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/1d/acd3ef8aabb7813c6ef2f91785d855583ac5cd7c3599e5c1a1a2ed1ec2e5/huggingface_hub-1.3.2-py3-none-any.whl", hash = "sha256:b552b9562a5532102a041fa31a6966bb9de95138fc7aa578bb3703198c25d1b6", size = 534504, upload-time = "2026-01-14T13:57:37.555Z" },
 ]
 
 [[package]]
@@ -760,6 +874,93 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/02/d52c733a2452ef1ffcc123b68e6606d07276b0e358db70eabad7e40042b7/pillow-12.1.0.tar.gz", hash = "sha256:5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9", size = 46977283, upload-time = "2026-01-02T09:13:29.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/c4/bf8328039de6cc22182c3ef007a2abfbbdab153661c0a9aa78af8d706391/pillow-12.1.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:a83e0850cb8f5ac975291ebfc4170ba481f41a28065277f7f735c202cd8e0af3", size = 5304057, upload-time = "2026-01-02T09:10:46.627Z" },
+    { url = "https://files.pythonhosted.org/packages/43/06/7264c0597e676104cc22ca73ee48f752767cd4b1fe084662620b17e10120/pillow-12.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b6e53e82ec2db0717eabb276aa56cf4e500c9a7cec2c2e189b55c24f65a3e8c0", size = 4657811, upload-time = "2026-01-02T09:10:49.548Z" },
+    { url = "https://files.pythonhosted.org/packages/72/64/f9189e44474610daf83da31145fa56710b627b5c4c0b9c235e34058f6b31/pillow-12.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:40a8e3b9e8773876d6e30daed22f016509e3987bab61b3b7fe309d7019a87451", size = 6232243, upload-time = "2026-01-02T09:10:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/30/0df458009be6a4caca4ca2c52975e6275c387d4e5c95544e34138b41dc86/pillow-12.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:800429ac32c9b72909c671aaf17ecd13110f823ddb7db4dfef412a5587c2c24e", size = 8037872, upload-time = "2026-01-02T09:10:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/86/95845d4eda4f4f9557e25381d70876aa213560243ac1a6d619c46caaedd9/pillow-12.1.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b022eaaf709541b391ee069f0022ee5b36c709df71986e3f7be312e46f42c84", size = 6345398, upload-time = "2026-01-02T09:10:55.426Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1f/8e66ab9be3aaf1435bc03edd1ebdf58ffcd17f7349c1d970cafe87af27d9/pillow-12.1.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f345e7bc9d7f368887c712aa5054558bad44d2a301ddf9248599f4161abc7c0", size = 7034667, upload-time = "2026-01-02T09:10:57.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f6/683b83cb9b1db1fb52b87951b1c0b99bdcfceaa75febf11406c19f82cb5e/pillow-12.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d70347c8a5b7ccd803ec0c85c8709f036e6348f1e6a5bf048ecd9c64d3550b8b", size = 6458743, upload-time = "2026-01-02T09:10:59.331Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/de833d63622538c1d58ce5395e7c6cb7e7dce80decdd8bde4a484e095d9f/pillow-12.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1fcc52d86ce7a34fd17cb04e87cfdb164648a3662a6f20565910a99653d66c18", size = 7159342, upload-time = "2026-01-02T09:11:01.82Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/40/50d86571c9e5868c42b81fe7da0c76ca26373f3b95a8dd675425f4a92ec1/pillow-12.1.0-cp311-cp311-win32.whl", hash = "sha256:3ffaa2f0659e2f740473bcf03c702c39a8d4b2b7ffc629052028764324842c64", size = 6328655, upload-time = "2026-01-02T09:11:04.556Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/af/b1d7e301c4cd26cd45d4af884d9ee9b6fab893b0ad2450d4746d74a6968c/pillow-12.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:806f3987ffe10e867bab0ddad45df1148a2b98221798457fa097ad85d6e8bc75", size = 7031469, upload-time = "2026-01-02T09:11:06.538Z" },
+    { url = "https://files.pythonhosted.org/packages/48/36/d5716586d887fb2a810a4a61518a327a1e21c8b7134c89283af272efe84b/pillow-12.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:9f5fefaca968e700ad1a4a9de98bf0869a94e397fe3524c4c9450c1445252304", size = 2452515, upload-time = "2026-01-02T09:11:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/20/31/dc53fe21a2f2996e1b7d92bf671cdb157079385183ef7c1ae08b485db510/pillow-12.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a332ac4ccb84b6dde65dbace8431f3af08874bf9770719d32a635c4ef411b18b", size = 5262642, upload-time = "2026-01-02T09:11:10.138Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c1/10e45ac9cc79419cedf5121b42dcca5a50ad2b601fa080f58c22fb27626e/pillow-12.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:907bfa8a9cb790748a9aa4513e37c88c59660da3bcfffbd24a7d9e6abf224551", size = 4657464, upload-time = "2026-01-02T09:11:12.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/26/7b82c0ab7ef40ebede7a97c72d473bda5950f609f8e0c77b04af574a0ddb/pillow-12.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:efdc140e7b63b8f739d09a99033aa430accce485ff78e6d311973a67b6bf3208", size = 6234878, upload-time = "2026-01-02T09:11:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/76/25/27abc9792615b5e886ca9411ba6637b675f1b77af3104710ac7353fe5605/pillow-12.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bef9768cab184e7ae6e559c032e95ba8d07b3023c289f79a2bd36e8bf85605a5", size = 8044868, upload-time = "2026-01-02T09:11:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ea/f200a4c36d836100e7bc738fc48cd963d3ba6372ebc8298a889e0cfc3359/pillow-12.1.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:742aea052cf5ab5034a53c3846165bc3ce88d7c38e954120db0ab867ca242661", size = 6349468, upload-time = "2026-01-02T09:11:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8f/48d0b77ab2200374c66d344459b8958c86693be99526450e7aee714e03e4/pillow-12.1.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6dfc2af5b082b635af6e08e0d1f9f1c4e04d17d4e2ca0ef96131e85eda6eb17", size = 7041518, upload-time = "2026-01-02T09:11:19.389Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/23/c281182eb986b5d31f0a76d2a2c8cd41722d6fb8ed07521e802f9bba52de/pillow-12.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:609e89d9f90b581c8d16358c9087df76024cf058fa693dd3e1e1620823f39670", size = 6462829, upload-time = "2026-01-02T09:11:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ef/7018273e0faac099d7b00982abdcc39142ae6f3bd9ceb06de09779c4a9d6/pillow-12.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43b4899cfd091a9693a1278c4982f3e50f7fb7cff5153b05174b4afc9593b616", size = 7166756, upload-time = "2026-01-02T09:11:23.559Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c8/993d4b7ab2e341fe02ceef9576afcf5830cdec640be2ac5bee1820d693d4/pillow-12.1.0-cp312-cp312-win32.whl", hash = "sha256:aa0c9cc0b82b14766a99fbe6084409972266e82f459821cd26997a488a7261a7", size = 6328770, upload-time = "2026-01-02T09:11:25.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/87/90b358775a3f02765d87655237229ba64a997b87efa8ccaca7dd3e36e7a7/pillow-12.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:d70534cea9e7966169ad29a903b99fc507e932069a881d0965a1a84bb57f6c6d", size = 7033406, upload-time = "2026-01-02T09:11:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/cf/881b457eccacac9e5b2ddd97d5071fb6d668307c57cbf4e3b5278e06e536/pillow-12.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:65b80c1ee7e14a87d6a068dd3b0aea268ffcabfe0498d38661b00c5b4b22e74c", size = 2452612, upload-time = "2026-01-02T09:11:29.309Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c7/2530a4aa28248623e9d7f27316b42e27c32ec410f695929696f2e0e4a778/pillow-12.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7b5dd7cbae20285cdb597b10eb5a2c13aa9de6cde9bb64a3c1317427b1db1ae1", size = 4062543, upload-time = "2026-01-02T09:11:31.566Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1f/40b8eae823dc1519b87d53c30ed9ef085506b05281d313031755c1705f73/pillow-12.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:29a4cef9cb672363926f0470afc516dbf7305a14d8c54f7abbb5c199cd8f8179", size = 4138373, upload-time = "2026-01-02T09:11:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/77/6fa60634cf06e52139fd0e89e5bbf055e8166c691c42fb162818b7fda31d/pillow-12.1.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:681088909d7e8fa9e31b9799aaa59ba5234c58e5e4f1951b4c4d1082a2e980e0", size = 3601241, upload-time = "2026-01-02T09:11:35.011Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/bf/28ab865de622e14b747f0cd7877510848252d950e43002e224fb1c9ababf/pillow-12.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:983976c2ab753166dc66d36af6e8ec15bb511e4a25856e2227e5f7e00a160587", size = 5262410, upload-time = "2026-01-02T09:11:36.682Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/34/583420a1b55e715937a85bd48c5c0991598247a1fd2eb5423188e765ea02/pillow-12.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:db44d5c160a90df2d24a24760bbd37607d53da0b34fb546c4c232af7192298ac", size = 4657312, upload-time = "2026-01-02T09:11:38.535Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/fd/f5a0896839762885b3376ff04878f86ab2b097c2f9a9cdccf4eda8ba8dc0/pillow-12.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6b7a9d1db5dad90e2991645874f708e87d9a3c370c243c2d7684d28f7e133e6b", size = 6232605, upload-time = "2026-01-02T09:11:40.602Z" },
+    { url = "https://files.pythonhosted.org/packages/98/aa/938a09d127ac1e70e6ed467bd03834350b33ef646b31edb7452d5de43792/pillow-12.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6258f3260986990ba2fa8a874f8b6e808cf5abb51a94015ca3dc3c68aa4f30ea", size = 8041617, upload-time = "2026-01-02T09:11:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e8/538b24cb426ac0186e03f80f78bc8dc7246c667f58b540bdd57c71c9f79d/pillow-12.1.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e115c15e3bc727b1ca3e641a909f77f8ca72a64fff150f666fcc85e57701c26c", size = 6346509, upload-time = "2026-01-02T09:11:44.955Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/632e58ec89a32738cabfd9ec418f0e9898a2b4719afc581f07c04a05e3c9/pillow-12.1.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6741e6f3074a35e47c77b23a4e4f2d90db3ed905cb1c5e6e0d49bff2045632bc", size = 7038117, upload-time = "2026-01-02T09:11:46.736Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a2/d40308cf86eada842ca1f3ffa45d0ca0df7e4ab33c83f81e73f5eaed136d/pillow-12.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:935b9d1aed48fcfb3f838caac506f38e29621b44ccc4f8a64d575cb1b2a88644", size = 6460151, upload-time = "2026-01-02T09:11:48.625Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/88/f5b058ad6453a085c5266660a1417bdad590199da1b32fb4efcff9d33b05/pillow-12.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5fee4c04aad8932da9f8f710af2c1a15a83582cfb884152a9caa79d4efcdbf9c", size = 7164534, upload-time = "2026-01-02T09:11:50.445Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ce/c17334caea1db789163b5d855a5735e47995b0b5dc8745e9a3605d5f24c0/pillow-12.1.0-cp313-cp313-win32.whl", hash = "sha256:a786bf667724d84aa29b5db1c61b7bfdde380202aaca12c3461afd6b71743171", size = 6332551, upload-time = "2026-01-02T09:11:52.234Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/07/74a9d941fa45c90a0d9465098fe1ec85de3e2afbdc15cc4766622d516056/pillow-12.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:461f9dfdafa394c59cd6d818bdfdbab4028b83b02caadaff0ffd433faf4c9a7a", size = 7040087, upload-time = "2026-01-02T09:11:54.822Z" },
+    { url = "https://files.pythonhosted.org/packages/88/09/c99950c075a0e9053d8e880595926302575bc742b1b47fe1bbcc8d388d50/pillow-12.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:9212d6b86917a2300669511ed094a9406888362e085f2431a7da985a6b124f45", size = 2452470, upload-time = "2026-01-02T09:11:56.522Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ba/970b7d85ba01f348dee4d65412476321d40ee04dcb51cd3735b9dc94eb58/pillow-12.1.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:00162e9ca6d22b7c3ee8e61faa3c3253cd19b6a37f126cad04f2f88b306f557d", size = 5264816, upload-time = "2026-01-02T09:11:58.227Z" },
+    { url = "https://files.pythonhosted.org/packages/10/60/650f2fb55fdba7a510d836202aa52f0baac633e50ab1cf18415d332188fb/pillow-12.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7d6daa89a00b58c37cb1747ec9fb7ac3bc5ffd5949f5888657dfddde6d1312e0", size = 4660472, upload-time = "2026-01-02T09:12:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/5273a99478956a099d533c4f46cbaa19fd69d606624f4334b85e50987a08/pillow-12.1.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2479c7f02f9d505682dc47df8c0ea1fc5e264c4d1629a5d63fe3e2334b89554", size = 6268974, upload-time = "2026-01-02T09:12:02.572Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/26/0bf714bc2e73d5267887d47931d53c4ceeceea6978148ed2ab2a4e6463c4/pillow-12.1.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f188d580bd870cda1e15183790d1cc2fa78f666e76077d103edf048eed9c356e", size = 8073070, upload-time = "2026-01-02T09:12:04.75Z" },
+    { url = "https://files.pythonhosted.org/packages/43/cf/1ea826200de111a9d65724c54f927f3111dc5ae297f294b370a670c17786/pillow-12.1.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0fde7ec5538ab5095cc02df38ee99b0443ff0e1c847a045554cf5f9af1f4aa82", size = 6380176, upload-time = "2026-01-02T09:12:06.626Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e0/7938dd2b2013373fd85d96e0f38d62b7a5a262af21ac274250c7ca7847c9/pillow-12.1.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ed07dca4a8464bada6139ab38f5382f83e5f111698caf3191cb8dbf27d908b4", size = 7067061, upload-time = "2026-01-02T09:12:08.624Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/a2aa97d37272a929a98437a8c0ac37b3cf012f4f8721e1bd5154699b2518/pillow-12.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f45bd71d1fa5e5749587613037b172e0b3b23159d1c00ef2fc920da6f470e6f0", size = 6491824, upload-time = "2026-01-02T09:12:10.488Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/44/80e46611b288d51b115826f136fb3465653c28f491068a72d3da49b54cd4/pillow-12.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:277518bf4fe74aa91489e1b20577473b19ee70fb97c374aa50830b279f25841b", size = 7190911, upload-time = "2026-01-02T09:12:12.772Z" },
+    { url = "https://files.pythonhosted.org/packages/86/77/eacc62356b4cf81abe99ff9dbc7402750044aed02cfd6a503f7c6fc11f3e/pillow-12.1.0-cp313-cp313t-win32.whl", hash = "sha256:7315f9137087c4e0ee73a761b163fc9aa3b19f5f606a7fc08d83fd3e4379af65", size = 6336445, upload-time = "2026-01-02T09:12:14.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3c/57d81d0b74d218706dafccb87a87ea44262c43eef98eb3b164fd000e0491/pillow-12.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:0ddedfaa8b5f0b4ffbc2fa87b556dc59f6bb4ecb14a53b33f9189713ae8053c0", size = 7045354, upload-time = "2026-01-02T09:12:16.599Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/82/8b9b97bba2e3576a340f93b044a3a3a09841170ab4c1eb0d5c93469fd32f/pillow-12.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:80941e6d573197a0c28f394753de529bb436b1ca990ed6e765cf42426abc39f8", size = 2454547, upload-time = "2026-01-02T09:12:18.704Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/87/bdf971d8bbcf80a348cc3bacfcb239f5882100fe80534b0ce67a784181d8/pillow-12.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:5cb7bc1966d031aec37ddb9dcf15c2da5b2e9f7cc3ca7c54473a20a927e1eb91", size = 4062533, upload-time = "2026-01-02T09:12:20.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/5eb37a681c68d605eb7034c004875c81f86ec9ef51f5be4a63eadd58859a/pillow-12.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:97e9993d5ed946aba26baf9c1e8cf18adbab584b99f452ee72f7ee8acb882796", size = 4138546, upload-time = "2026-01-02T09:12:23.664Z" },
+    { url = "https://files.pythonhosted.org/packages/11/6d/19a95acb2edbace40dcd582d077b991646b7083c41b98da4ed7555b59733/pillow-12.1.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:414b9a78e14ffeb98128863314e62c3f24b8a86081066625700b7985b3f529bd", size = 3601163, upload-time = "2026-01-02T09:12:26.338Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/36/2b8138e51cb42e4cc39c3297713455548be855a50558c3ac2beebdc251dd/pillow-12.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e6bdb408f7c9dd2a5ff2b14a3b0bb6d4deb29fb9961e6eb3ae2031ae9a5cec13", size = 5266086, upload-time = "2026-01-02T09:12:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/649056e4d22e1caa90816bf99cef0884aed607ed38075bd75f091a607a38/pillow-12.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3413c2ae377550f5487991d444428f1a8ae92784aac79caa8b1e3b89b175f77e", size = 4657344, upload-time = "2026-01-02T09:12:31.117Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6b/c5742cea0f1ade0cd61485dc3d81f05261fc2276f537fbdc00802de56779/pillow-12.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e5dcbe95016e88437ecf33544ba5db21ef1b8dd6e1b434a2cb2a3d605299e643", size = 6232114, upload-time = "2026-01-02T09:12:32.936Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/8f/9f521268ce22d63991601aafd3d48d5ff7280a246a1ef62d626d67b44064/pillow-12.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d0a7735df32ccbcc98b98a1ac785cc4b19b580be1bdf0aeb5c03223220ea09d5", size = 8042708, upload-time = "2026-01-02T09:12:34.78Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/eb/257f38542893f021502a1bbe0c2e883c90b5cff26cc33b1584a841a06d30/pillow-12.1.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c27407a2d1b96774cbc4a7594129cc027339fd800cd081e44497722ea1179de", size = 6347762, upload-time = "2026-01-02T09:12:36.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5a/8ba375025701c09b309e8d5163c5a4ce0102fa86bbf8800eb0d7ac87bc51/pillow-12.1.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15c794d74303828eaa957ff8070846d0efe8c630901a1c753fdc63850e19ecd9", size = 7039265, upload-time = "2026-01-02T09:12:39.082Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/dc/cf5e4cdb3db533f539e88a7bbf9f190c64ab8a08a9bc7a4ccf55067872e4/pillow-12.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c990547452ee2800d8506c4150280757f88532f3de2a58e3022e9b179107862a", size = 6462341, upload-time = "2026-01-02T09:12:40.946Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/47/0291a25ac9550677e22eda48510cfc4fa4b2ef0396448b7fbdc0a6946309/pillow-12.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b63e13dd27da389ed9475b3d28510f0f954bca0041e8e551b2a4eb1eab56a39a", size = 7165395, upload-time = "2026-01-02T09:12:42.706Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4c/e005a59393ec4d9416be06e6b45820403bb946a778e39ecec62f5b2b991e/pillow-12.1.0-cp314-cp314-win32.whl", hash = "sha256:1a949604f73eb07a8adab38c4fe50791f9919344398bdc8ac6b307f755fc7030", size = 6431413, upload-time = "2026-01-02T09:12:44.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/af/f23697f587ac5f9095d67e31b81c95c0249cd461a9798a061ed6709b09b5/pillow-12.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f9f6a650743f0ddee5593ac9e954ba1bdbc5e150bc066586d4f26127853ab94", size = 7176779, upload-time = "2026-01-02T09:12:46.727Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/36/6a51abf8599232f3e9afbd16d52829376a68909fe14efe29084445db4b73/pillow-12.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:808b99604f7873c800c4840f55ff389936ef1948e4e87645eaf3fccbc8477ac4", size = 2543105, upload-time = "2026-01-02T09:12:49.243Z" },
+    { url = "https://files.pythonhosted.org/packages/82/54/2e1dd20c8749ff225080d6ba465a0cab4387f5db0d1c5fb1439e2d99923f/pillow-12.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc11908616c8a283cf7d664f77411a5ed2a02009b0097ff8abbba5e79128ccf2", size = 5268571, upload-time = "2026-01-02T09:12:51.11Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/571163a5ef86ec0cf30d265ac2a70ae6fc9e28413d1dc94fa37fae6bda89/pillow-12.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:896866d2d436563fa2a43a9d72f417874f16b5545955c54a64941e87c1376c61", size = 4660426, upload-time = "2026-01-02T09:12:52.865Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e1/53ee5163f794aef1bf84243f755ee6897a92c708505350dd1923f4afec48/pillow-12.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8e178e3e99d3c0ea8fc64b88447f7cac8ccf058af422a6cedc690d0eadd98c51", size = 6269908, upload-time = "2026-01-02T09:12:54.884Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0b/b4b4106ff0ee1afa1dc599fde6ab230417f800279745124f6c50bcffed8e/pillow-12.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:079af2fb0c599c2ec144ba2c02766d1b55498e373b3ac64687e43849fbbef5bc", size = 8074733, upload-time = "2026-01-02T09:12:56.802Z" },
+    { url = "https://files.pythonhosted.org/packages/19/9f/80b411cbac4a732439e629a26ad3ef11907a8c7fc5377b7602f04f6fe4e7/pillow-12.1.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdec5e43377761c5dbca620efb69a77f6855c5a379e32ac5b158f54c84212b14", size = 6381431, upload-time = "2026-01-02T09:12:58.823Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b7/d65c45db463b66ecb6abc17c6ba6917a911202a07662247e1355ce1789e7/pillow-12.1.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:565c986f4b45c020f5421a4cea13ef294dde9509a8577f29b2fc5edc7587fff8", size = 7068529, upload-time = "2026-01-02T09:13:00.885Z" },
+    { url = "https://files.pythonhosted.org/packages/50/96/dfd4cd726b4a45ae6e3c669fc9e49deb2241312605d33aba50499e9d9bd1/pillow-12.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:43aca0a55ce1eefc0aefa6253661cb54571857b1a7b2964bd8a1e3ef4b729924", size = 6492981, upload-time = "2026-01-02T09:13:03.314Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/1c/b5dc52cf713ae46033359c5ca920444f18a6359ce1020dd3e9c553ea5bc6/pillow-12.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0deedf2ea233722476b3a81e8cdfbad786f7adbed5d848469fa59fe52396e4ef", size = 7191878, upload-time = "2026-01-02T09:13:05.276Z" },
+    { url = "https://files.pythonhosted.org/packages/53/26/c4188248bd5edaf543864fe4834aebe9c9cb4968b6f573ce014cc42d0720/pillow-12.1.0-cp314-cp314t-win32.whl", hash = "sha256:b17fbdbe01c196e7e159aacb889e091f28e61020a8abeac07b68079b6e626988", size = 6438703, upload-time = "2026-01-02T09:13:07.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0e/69ed296de8ea05cb03ee139cee600f424ca166e632567b2d66727f08c7ed/pillow-12.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27b9baecb428899db6c0de572d6d305cfaf38ca1596b5c0542a5182e3e74e8c6", size = 7182927, upload-time = "2026-01-02T09:13:09.841Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f5/68334c015eed9b5cff77814258717dec591ded209ab5b6fb70e2ae873d1d/pillow-12.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f61333d817698bdcdd0f9d7793e365ac3d2a21c1f1eb02b32ad6aefb8d8ea831", size = 2545104, upload-time = "2026-01-02T09:13:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/bc/224b1d98cffd7164b14707c91aac83c07b047fbd8f58eba4066a3e53746a/pillow-12.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ca94b6aac0d7af2a10ba08c0f888b3d5114439b6b3ef39968378723622fed377", size = 5228605, upload-time = "2026-01-02T09:13:14.084Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ca/49ca7769c4550107de049ed85208240ba0f330b3f2e316f24534795702ce/pillow-12.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:351889afef0f485b84078ea40fe33727a0492b9af3904661b0abbafee0355b72", size = 4622245, upload-time = "2026-01-02T09:13:15.964Z" },
+    { url = "https://files.pythonhosted.org/packages/73/48/fac807ce82e5955bcc2718642b94b1bd22a82a6d452aea31cbb678cddf12/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb0984b30e973f7e2884362b7d23d0a348c7143ee559f38ef3eaab640144204c", size = 5247593, upload-time = "2026-01-02T09:13:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/95/3e0742fe358c4664aed4fd05d5f5373dcdad0b27af52aa0972568541e3f4/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:84cabc7095dd535ca934d57e9ce2a72ffd216e435a84acb06b2277b1de2689bd", size = 6989008, upload-time = "2026-01-02T09:13:20.083Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/74/fe2ac378e4e202e56d50540d92e1ef4ff34ed687f3c60f6a121bcf99437e/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53d8b764726d3af1a138dd353116f774e3862ec7e3794e0c8781e30db0f35dfc", size = 5313824, upload-time = "2026-01-02T09:13:22.405Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/77/2a60dee1adee4e2655ac328dd05c02a955c1cd683b9f1b82ec3feb44727c/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5da841d81b1a05ef940a8567da92decaa15bc4d7dedb540a8c219ad83d91808a", size = 5963278, upload-time = "2026-01-02T09:13:24.706Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/64e9b1c7f04ae0027f788a248e6297d7fcc29571371fe7d45495a78172c0/pillow-12.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:75af0b4c229ac519b155028fa1be632d812a519abba9b46b20e50c6caa184f19", size = 7029809, upload-time = "2026-01-02T09:13:26.541Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -826,6 +1027,61 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -864,6 +1120,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/54/6177a0dc10bce6f43e392a2192e6018755473283d0cf43cc7e6afc182aea/ruff-0.13.1-py3-none-win32.whl", hash = "sha256:55e9efa692d7cb18580279f1fbb525146adc401f40735edf0aaeabd93099f9a0", size = 12178448, upload-time = "2025-09-18T19:52:35.545Z" },
     { url = "https://files.pythonhosted.org/packages/64/51/c6a3a33d9938007b8bdc8ca852ecc8d810a407fb513ab08e34af12dc7c24/ruff-0.13.1-py3-none-win_amd64.whl", hash = "sha256:3a3fb595287ee556de947183489f636b9f76a72f0fa9c028bdcabf5bab2cc5e5", size = 13286458, upload-time = "2025-09-18T19:52:38.198Z" },
     { url = "https://files.pythonhosted.org/packages/fd/04/afc078a12cf68592345b1e2d6ecdff837d286bac023d7a22c54c7a698c5b/ruff-0.13.1-py3-none-win_arm64.whl", hash = "sha256:c0bae9ffd92d54e03c2bf266f466da0a65e145f298ee5b5846ed435f6a00518a", size = 12437893, upload-time = "2025-09-18T19:52:41.283Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
 ]
 
 [[package]]
@@ -986,6 +1264,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "soundfile"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1086,6 +1373,22 @@ wheels = [
 ]
 
 [[package]]
+name = "timm"
+version = "1.0.24"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/9d/0ea45640be447445c8664ce2b10c74f763b0b0b9ed11620d41a4d4baa10c/timm-1.0.24.tar.gz", hash = "sha256:c7b909f43fe2ef8fe62c505e270cd4f1af230dfbc37f2ee93e3608492b9d9a40", size = 2412239, upload-time = "2026-01-07T00:26:17.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/dd/c1f5b0890f7b5db661bde0864b41cb0275be76851047e5f7e085fe0b455a/timm-1.0.24-py3-none-any.whl", hash = "sha256:8301ac783410c6ad72c73c49326af6d71a9e4d1558238552796e825c2464913f", size = 2560563, upload-time = "2026-01-07T00:26:13.956Z" },
+]
+
+[[package]]
 name = "torch"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1159,6 +1462,34 @@ wheels = [
 ]
 
 [[package]]
+name = "torchvision"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/d7/15d3d7bd8d0239211b21673d1bac7bc345a4ad904a8e25bb3fd8a9cf1fbc/torchvision-0.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:49aa20e21f0c2bd458c71d7b449776cbd5f16693dd5807195a820612b8a229b7", size = 1856884, upload-time = "2025-08-06T14:58:00.237Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/14/7b44fe766b7d11e064c539d92a172fa9689a53b69029e24f2f1f51e7dc56/torchvision-0.23.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:01dc33ee24c79148aee7cdbcf34ae8a3c9da1674a591e781577b716d233b1fa6", size = 2395543, upload-time = "2025-08-06T14:58:04.373Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fcb09aff941c8147d9e6aa6c8f67412a05622b0c750bcf796be4c85a58d4/torchvision-0.23.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:35c27941831b653f5101edfe62c03d196c13f32139310519e8228f35eae0e96a", size = 8628388, upload-time = "2025-08-06T14:58:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/93/40/3415d890eb357b25a8e0a215d32365a88ecc75a283f75c4e919024b22d97/torchvision-0.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:09bfde260e7963a15b80c9e442faa9f021c7e7f877ac0a36ca6561b367185013", size = 1600741, upload-time = "2025-08-06T14:57:59.158Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1d/0ea0b34bde92a86d42620f29baa6dcbb5c2fc85990316df5cb8f7abb8ea2/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440", size = 1856885, upload-time = "2025-08-06T14:58:06.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/00/2f6454decc0cd67158c7890364e446aad4b91797087a57a78e72e1a8f8bc/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948", size = 2396614, upload-time = "2025-08-06T14:58:03.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b5/3e580dcbc16f39a324f3dd71b90edbf02a42548ad44d2b4893cc92b1194b/torchvision-0.23.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4e7d31c43bc7cbecbb1a5652ac0106b436aa66e26437585fc2c4b2cf04d6014c", size = 8627108, upload-time = "2025-08-06T14:58:12.956Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c1/c2fe6d61e110a8d0de2f94276899a2324a8f1e6aee559eb6b4629ab27466/torchvision-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2e45272abe7b8bf0d06c405e78521b5757be1bd0ed7e5cd78120f7fdd4cbf35", size = 1600723, upload-time = "2025-08-06T14:57:57.986Z" },
+    { url = "https://files.pythonhosted.org/packages/91/37/45a5b9407a7900f71d61b2b2f62db4b7c632debca397f205fdcacb502780/torchvision-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c37e325e09a184b730c3ef51424f383ec5745378dc0eca244520aca29722600", size = 1856886, upload-time = "2025-08-06T14:58:05.491Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/da/a06c60fc84fc849377cf035d3b3e9a1c896d52dbad493b963c0f1cdd74d0/torchvision-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2f7fd6c15f3697e80627b77934f77705f3bc0e98278b989b2655de01f6903e1d", size = 2353112, upload-time = "2025-08-06T14:58:26.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/27/5ce65ba5c9d3b7d2ccdd79892ab86a2f87ac2ca6638f04bb0280321f1a9c/torchvision-0.23.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a76fafe113b2977be3a21bf78f115438c1f88631d7a87203acb3dd6ae55889e6", size = 8627658, upload-time = "2025-08-06T14:58:15.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e4/028a27b60aa578a2fa99d9d7334ff1871bb17008693ea055a2fdee96da0d/torchvision-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:07d069cb29691ff566e3b7f11f20d91044f079e1dbdc9d72e0655899a9b06938", size = 1600749, upload-time = "2025-08-06T14:58:10.719Z" },
+    { url = "https://files.pythonhosted.org/packages/05/35/72f91ad9ac7c19a849dedf083d347dc1123f0adeb401f53974f84f1d04c8/torchvision-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:2df618e1143805a7673aaf82cb5720dd9112d4e771983156aaf2ffff692eebf9", size = 2047192, upload-time = "2025-08-06T14:58:11.813Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9d/406cea60a9eb9882145bcd62a184ee61e823e8e1d550cdc3c3ea866a9445/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a3299d2b1d5a7aed2d3b6ffb69c672ca8830671967eb1cee1497bacd82fe47b", size = 2359295, upload-time = "2025-08-06T14:58:17.469Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f4/34662f71a70fa1e59de99772142f22257ca750de05ccb400b8d2e3809c1d/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:76bc4c0b63d5114aa81281390f8472a12a6a35ce9906e67ea6044e5af4cab60c", size = 8800474, upload-time = "2025-08-06T14:58:22.53Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/b5a2d841a8d228b5dbda6d524704408e19e7ca6b7bb0f24490e081da1fa1/torchvision-0.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b9e2dabf0da9c8aa9ea241afb63a8f3e98489e706b22ac3f30416a1be377153b", size = 1527667, upload-time = "2025-08-06T14:58:14.446Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1182,6 +1513,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
     { url = "https://files.pythonhosted.org/packages/20/63/8cb444ad5cdb25d999b7d647abac25af0ee37d292afc009940c05b82dda0/triton-3.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7936b18a3499ed62059414d7df563e6c163c5e16c3773678a3ee3d417865035d", size = 155659780, upload-time = "2025-07-30T19:58:51.171Z" },
+]
+
+[[package]]
+name = "typer-slim"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/d4/064570dec6358aa9049d4708e4a10407d74c99258f8b2136bb8702303f1a/typer_slim-0.21.1.tar.gz", hash = "sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd", size = 110478, upload-time = "2026-01-06T11:21:11.176Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/0a/4aca634faf693e33004796b6cee0ae2e1dba375a800c16ab8d3eff4bb800/typer_slim-0.21.1-py3-none-any.whl", hash = "sha256:6e6c31047f171ac93cc5a973c9e617dbc5ab2bddc4d0a3135dc161b4e2020e0d", size = 47444, upload-time = "2026-01-06T11:21:12.441Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
@ChrisNick92 @ellievak 

# Summary
This PR integrates PaSST as a backbone into the SDK. In more detail: 
- [Commit 3db537e651f95a5c353b147557e31c819457990c](https://github.com/magcil/deepaudio-x/commit/3db537e651f95a5c353b147557e31c819457990c): A pre-trained variant of the PaSST transformer-based model was added
- [Commit 2676d87fbe85656d9147af4aa9980b7b8cb286eb](https://github.com/magcil/deepaudio-x/commit/2676d87fbe85656d9147af4aa9980b7b8cb286eb): The codebases of BEATs and PaSST were cleaned and formatted with the use of Ruff  
- [Commit 012dd6f7ea661308494d2ced70521a17f2b187c3](https://github.com/magcil/deepaudio-x/commit/012dd6f7ea661308494d2ced70521a17f2b187c3):  PaSST was included in the testing pipeline

# About PaSST
The source code of PaSST can be found either in [the official GitHub repo](https://github.com/kkoutini/PaSST/tree/main) or [a stripped down version of this repo](https://github.com/kkoutini/passt_hear21) focused on the HEAR 2021 NeurIPS Challenge.

The codebase of PaSST is designed to handle a wide variety of pre-trained variants. However, we focused on a PaSST-S variant pre-trained on AudioSet (the correspoding weights can be downloaded from [this link](https://github.com/kkoutini/PaSST/releases/download/v.0.0.9/passt-s-kd-ap.486.pt)).

Hence, the code was refactored to retain only the functionality needed to load the model and forward a Torch input. The main access point to the PaSST model is [passt.py](https://github.com/magcil/deepaudio-x/blob/39-integrate-passt-as-backbone-updated/src/deepaudiox/modules/backbones/passt/passt.py). Additionally, an audio feature extractor and a list of modules and functions required for constructing PaSST  have been added in [preprocess.py](https://github.com/magcil/deepaudio-x/blob/39-integrate-passt-as-backbone-updated/src/deepaudiox/modules/backbones/passt/preprocess.py), [modules.py](https://github.com/magcil/deepaudio-x/blob/39-integrate-passt-as-backbone-updated/src/deepaudiox/modules/backbones/passt/modules.py) and [vit_helpers.py](https://github.com/magcil/deepaudio-x/blob/39-integrate-passt-as-backbone-updated/src/deepaudiox/modules/backbones/passt/vit_helpers.py), correspondingly.

# Checklist
- [x] Scanned and formatted the commited code using ruff.