### PR TITLE
[Issue #56] Refine inference pipelines, training loop decomposition, and API cleanup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.11"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Welcome to DeepAudioX SDK.")
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepaudio-x"
-version = "0.4.0"
+version = "0.4.1"
 description = "DeepAudio-X: Self-supervised audio toolkit for audio classification and beyond."
 authors = [
   { name = "Christos Nikou", email = "chrisnick92@gmail.com" }, 

--- a/src/deepaudiox/__init__.py
+++ b/src/deepaudiox/__init__.py
@@ -2,7 +2,7 @@
 This page provides the core API reference for DeepAudioX.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from deepaudiox.datasets.audio_classification_dataset import (  # noqa: F401
     AudioClassificationDataset,

--- a/src/deepaudiox/__init__.py
+++ b/src/deepaudiox/__init__.py
@@ -4,7 +4,6 @@ This page provides the core API reference for DeepAudioX.
 
 __version__ = "0.4.0"
 
-# Top-level API exports
 from deepaudiox.datasets.audio_classification_dataset import (  # noqa: F401
     AudioClassificationDataset,
     audio_classification_dataset_from_dictionary,
@@ -12,33 +11,25 @@ from deepaudiox.datasets.audio_classification_dataset import (  # noqa: F401
 )
 from deepaudiox.loops.evaluator import Evaluator  # noqa: F401
 from deepaudiox.loops.trainer import Trainer  # noqa: F401
-from deepaudiox.modules.backbones import BACKBONES  # noqa: F401
 from deepaudiox.modules.constructors import (  # noqa: F401
-    AudioClassifierConstructor,
-    BackboneConstructor,
+    AudioClassifierConstructor as AudioClassifier,
 )
-from deepaudiox.modules.pooling import POOLING  # noqa: F401
+from deepaudiox.modules.constructors import (
+    BackboneConstructor as Backbone,
+)
 from deepaudiox.utils.training_utils import (  # noqa: F401
     get_class_mapping_from_dir,
     get_class_mapping_from_list,
 )
 
-# User-friendly aliases
-AudioClassifier = AudioClassifierConstructor
-Backbone = BackboneConstructor
-
 __all__ = [
     "AudioClassifier",
-    "AudioClassifierConstructor",
-    "AudioClassificationDataset",
     "Backbone",
-    "BackboneConstructor",
-    "Evaluator",
-    "Trainer",
-    "BACKBONES",
-    "POOLING",
+    "AudioClassificationDataset",
     "audio_classification_dataset_from_dictionary",
     "audio_classification_dataset_from_dir",
+    "Evaluator",
+    "Trainer",
     "get_class_mapping_from_dir",
     "get_class_mapping_from_list",
 ]

--- a/src/deepaudiox/datasets/audio_classification_dataset.py
+++ b/src/deepaudiox/datasets/audio_classification_dataset.py
@@ -5,7 +5,7 @@ import librosa
 import soundfile as sf
 from torch.utils.data import Dataset
 
-from deepaudiox.dtos.dataset_items import AudioClassificationItem
+from deepaudiox.schemas.items import AudioClassificationItem
 
 
 class AudioClassificationDataset(Dataset):
@@ -103,21 +103,20 @@ class AudioClassificationDataset(Dataset):
 
     def _apply_segmentation(self, segment_duration: float | None):
         """Segmentize all audio files into fixed-duration segments.
-        Drops the last partial segment.
+        Drops the last partial segment. Files shorter than segment_duration are excluded.
         """
-
-        for item in list(self.items):
+        valid_items = []
+        for item in self.items:
             with sf.SoundFile(item.path) as f:
                 total_duration = len(f) / f.samplerate  # seconds
 
             if total_duration < segment_duration:
-                continue  # or raise, depending on your policy
+                continue
 
             num_segments = int(total_duration // segment_duration)
 
-            # seg_idx=0 already exists
-            for seg_idx in range(1, num_segments):
-                self.items.append(
+            for seg_idx in range(num_segments):
+                valid_items.append(
                     AudioClassificationItem(
                         path=item.path,
                         y_true=item.y_true,
@@ -125,6 +124,8 @@ class AudioClassificationDataset(Dataset):
                         class_name=item.class_name,
                     )
                 )
+
+        self.items = valid_items
 
 
 def audio_classification_dataset_from_dir(
@@ -157,7 +158,7 @@ def audio_classification_dataset_from_dir(
     file_to_class_mapping = {}
 
     subdirs = [d for d in root_path.iterdir() if d.is_dir()]
-    for _idx, subdir in enumerate(sorted(subdirs)):
+    for subdir in sorted(subdirs):
         audio_files = list(subdir.glob("**/*.wav")) + list(subdir.glob("**/*.mp3"))
         for audio_file in audio_files:
             file_to_class_mapping[audio_file] = subdir.name

--- a/src/deepaudiox/loops/evaluator.py
+++ b/src/deepaudiox/loops/evaluator.py
@@ -102,6 +102,7 @@ class Evaluator:
         # Configure callbacks
         self.callbacks = [ConsoleLogger(logger=self.logger), Reporter(logger=self.logger)]
 
+    @torch.inference_mode()
     def evaluate(self) -> None:
         """Run the full evaluation loop over the test set.
 
@@ -116,11 +117,12 @@ class Evaluator:
 
         Note:
             The model is expected to already be in eval mode (set in ``__init__``).
+            Runs under ``torch.inference_mode()`` — gradients are fully disabled.
             Callbacks (``ConsoleLogger``, ``Reporter``) are executed once after the loop.
         """
         # Lists to accumulate evaluation results, i.e., true_labels, prediction_labels, and posteriors
         y_true_batches, y_pred_batches, posterior_batches = [], [], []
-        with torch.no_grad(), tqdm(self.test_dloader, unit="batch", leave=False, desc="Evaluation phase") as tbar:
+        with tqdm(self.test_dloader, unit="batch", leave=False, desc="Evaluation phase") as tbar:
             for batch in tbar:
                 # Move inputs
                 x = batch["feature"].to(self.device)

--- a/src/deepaudiox/loops/evaluator.py
+++ b/src/deepaudiox/loops/evaluator.py
@@ -102,8 +102,24 @@ class Evaluator:
         # Configure callbacks
         self.callbacks = [ConsoleLogger(logger=self.logger), Reporter(logger=self.logger)]
 
-    def evaluate(self):
-        """Perform the testing process."""
+    def evaluate(self) -> None:
+        """Run the full evaluation loop over the test set.
+
+        Iterates over all batches in ``test_dloader``, accumulates true labels,
+        predicted labels, and posterior probabilities into ``self.state``, then
+        triggers the registered callbacks via ``on_testing_end``.
+
+        After this method returns, ``self.state`` holds:
+            - ``y_true`` (np.ndarray): Ground-truth class indices, shape (N,).
+            - ``y_pred`` (np.ndarray): Predicted class indices, shape (N,).
+            - ``posteriors`` (np.ndarray): Max posterior probability per sample, shape (N,).
+
+        Note:
+            The model is expected to already be in eval mode (set in ``__init__``).
+            Callbacks (``ConsoleLogger``, ``Reporter``) are executed once after the loop.
+        """
+        # Lists to accumulate evaluation results, i.e., true_labels, prediction_labels, and posteriors
+        y_true_batches, y_pred_batches, posterior_batches = [], [], []
         with torch.no_grad(), tqdm(self.test_dloader, unit="batch", leave=False, desc="Evaluation phase") as tbar:
             for batch in tbar:
                 # Move inputs
@@ -115,10 +131,15 @@ class Evaluator:
                 y_pred = np.array(inference["y_preds"], dtype=int)
                 post = np.array(inference["posteriors"], dtype=float)
 
-                # Update testing state (NumPy arrays)
-                self.state.y_true = np.concatenate([self.state.y_true, y_true])
-                self.state.y_pred = np.concatenate([self.state.y_pred, y_pred])
-                self.state.posteriors = np.concatenate([self.state.posteriors, post])
+                # Update lists with new batch results
+                y_true_batches.append(y_true)
+                y_pred_batches.append(y_pred)
+                posterior_batches.append(post)
+
+        # Concatenate all results outside the loop
+        self.state.y_true = np.concatenate(y_true_batches)
+        self.state.y_pred = np.concatenate(y_pred_batches)
+        self.state.posteriors = np.concatenate(posterior_batches)
 
         # Execute callbacks at the end of testing
         for cb in self.callbacks:

--- a/src/deepaudiox/loops/trainer.py
+++ b/src/deepaudiox/loops/trainer.py
@@ -137,76 +137,116 @@ class Trainer:
             EarlyStopper(patience=patience, logger=self.logger),
         ]
 
-    def train(self) -> None:
-        """Perform the training process"""
+    def train_step(self) -> float:
+        """Run one pass over the training set.
 
-        # Execute callbacks in the beginning of training
+        Sets the model to train mode, iterates over ``train_dloader``,
+        performs forward + backward + optimizer step per batch.
+
+        Returns:
+            float: Average training loss over the epoch.
+        """
+        train_loss = 0.0
+        self.model.train()
+        with tqdm(self.train_dloader, unit="batch", leave=False, desc="Training phase") as tbar:
+            for batch in tbar:
+                self.optimizer.zero_grad()
+                x = batch["feature"].to(self.device)
+                y_true = batch["y_true"].to(self.device)
+                y_pred = self.model(x)
+                batch_loss = self.loss_function(y_pred, y_true)
+                batch_loss.backward()
+                self.optimizer.step()
+                train_loss += batch_loss.item()
+        return train_loss / max(1, len(self.train_dloader))
+
+    def val_step(self) -> float:
+        """Run one pass over the validation set.
+
+        Sets the model to eval mode, iterates over ``validation_dloader``
+        under ``torch.no_grad()``.
+
+        Returns:
+            float: Average validation loss over the epoch.
+        """
+        val_loss = 0.0
+        self.model.eval()
+        with torch.no_grad(), tqdm(self.validation_dloader, unit="batch", leave=False, desc="Validation phase") as vbar:
+            for batch in vbar:
+                x = batch["feature"].to(self.device)
+                y_true = batch["y_true"].to(self.device)
+                y_pred = self.model(x)
+                batch_loss = self.loss_function(y_pred, y_true)
+                val_loss += batch_loss.item()
+        return val_loss / len(self.validation_dloader)
+
+    def epoch_step(self) -> tuple[float, float]:
+        """Run one complete training epoch.
+
+        Executes ``on_epoch_start`` callbacks, calls ``train_step()`` and
+        ``val_step()``, updates the LR scheduler and ``self.state``, then
+        executes ``on_epoch_end`` callbacks (which may trigger early stopping
+        or checkpointing).
+
+        Note:
+            ``self.state.current_epoch`` must be set by the caller before
+            invoking this method — ``train()`` does this automatically.
+            When calling ``epoch_step()`` directly, set it yourself:
+            ``trainer.state.current_epoch = epoch``.
+
+        Returns:
+            tuple[float, float]: ``(train_loss, val_loss)`` for the epoch.
+
+        Example:
+            >>> from deepaudiox import AudioClassifier, Trainer
+            >>> from deepaudiox import audio_classification_dataset_from_dir, get_class_mapping_from_dir
+            >>> class_mapping = get_class_mapping_from_dir(root_dir="path/to/data")
+            >>> train_dataset = audio_classification_dataset_from_dir(
+            ...     root_dir="path/to/data",
+            ...     sample_rate=16_000,
+            ...     class_mapping=class_mapping,
+            ... )
+            >>> model = AudioClassifier(num_classes=len(class_mapping), backbone="beats", sample_rate=16_000)
+            >>> trainer = Trainer(train_dset=train_dataset, model=model, epochs=10)
+            >>> for epoch in range(1, trainer.epochs + 1):
+            ...     trainer.state.current_epoch = epoch
+            ...     train_loss, val_loss = trainer.epoch_step()
+            ...     print(f"Epoch {epoch} — train: {train_loss:.4f}, val: {val_loss:.4f}")
+            ...     if trainer.state.early_stop:
+            ...         break
+        """
+        for cb in self.callbacks:
+            cb.on_epoch_start(self)
+
+        train_loss = self.train_step()
+        val_loss = self.val_step()
+
+        if isinstance(self.scheduler, ReduceLROnPlateau):
+            self.scheduler.step(val_loss)
+        else:
+            self.scheduler.step()
+
+        self.state.train_loss.append(train_loss)
+        self.state.validation_loss.append(val_loss)
+
+        for cb in self.callbacks:
+            cb.on_epoch_end(self)
+
+        return train_loss, val_loss
+
+    def train(self) -> None:
+        """Perform the full training process."""
         for cb in self.callbacks:
             cb.on_train_start(self)
 
-        # Initiate training
         for epoch in range(1, self.epochs + 1):
             if self.state.early_stop:
                 break
-
             self.state.current_epoch = epoch
-            train_loss, val_loss = 0.0, 0.0
+            self.epoch_step()
 
-            # Execute callbacks in the beginning of the epoch
-            for cb in self.callbacks:
-                cb.on_epoch_start(self)
-
-            # Perform trainng
-            self.model.train()
-            with tqdm(self.train_dloader, unit="batch", leave=False, desc="Training phase") as tbar:
-                # Optimize the model by batch
-                for batch in tbar:
-                    self.optimizer.zero_grad()
-                    x = batch["feature"].to(self.device)
-                    y_true = batch["y_true"].to(self.device)
-                    y_pred = self.model(x)
-                    batch_loss = self.loss_function(y_pred, y_true)
-                    batch_loss.backward()
-                    self.optimizer.step()
-
-                    train_loss += batch_loss.item()
-
-                train_loss /= max(1, len(self.train_dloader))
-
-            # Perform validation
-            self.model.eval()
-            with torch.no_grad():
-                with tqdm(self.validation_dloader, unit="batch", leave=False, desc="Validation phase") as vbar:
-                    # Compute validation loss by batch
-                    for batch in vbar:
-                        x = batch["feature"].to(self.device)
-                        y_true = batch["y_true"].to(self.device)
-                        y_pred = self.model(x)
-                        batch_loss = self.loss_function(y_pred, y_true)
-                        val_loss += batch_loss.item()
-
-                val_loss /= len(self.validation_dloader)
-
-            # Update scheduling
-            if self.scheduler:
-                if isinstance(self.scheduler, ReduceLROnPlateau):
-                    self.scheduler.step(val_loss)
-                else:
-                    self.scheduler.step()
-
-            # Update training state
-            self.state.train_loss.append(train_loss)
-            self.state.validation_loss.append(val_loss)
-
-            # Execute callbacks at the end of the epoch
-            for cb in self.callbacks:
-                cb.on_epoch_end(self)
-
-        # Execute callbacks at the end of training
         for cb in self.callbacks:
             cb.on_train_end(self)
-
-        return
 
     def _setup_dataloaders(
         self,

--- a/src/deepaudiox/modules/backbones/__init__.py
+++ b/src/deepaudiox/modules/backbones/__init__.py
@@ -1,5 +1,6 @@
 # deepaudiox/modules/backbones/__init__.py
 
+import warnings
 from collections.abc import Callable
 
 from deepaudiox.modules.backbones.beats.beats_modules.BEATs import BEATs
@@ -26,7 +27,9 @@ def register_backbone(name: str):
 @register_backbone("beats")
 def beats_base() -> BEATs:
     """BEATs backbone without DivEncLayer."""
-    return BEATs()
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning, module="torch.nn.utils.weight_norm")
+        return BEATs()
 
 
 @register_backbone("passt")

--- a/src/deepaudiox/modules/backbones/__init__.py
+++ b/src/deepaudiox/modules/backbones/__init__.py
@@ -36,18 +36,18 @@ def passt_base() -> PaSST:
 
 
 @register_backbone("mobilenet_05_as")
-def monilenet_05_base() -> MobileNet:
+def mobilenet_05_base() -> MobileNet:
     """MobileNet backbone"""
     return MobileNet(cfg=MobileNetConfig({"width_mult": 0.5}))
 
 
 @register_backbone("mobilenet_10_as")
-def monilenet_10_base() -> MobileNet:
+def mobilenet_10_base() -> MobileNet:
     """MobileNet backbone"""
     return MobileNet(cfg=MobileNetConfig({"width_mult": 1}))
 
 
 @register_backbone("mobilenet_40_as")
-def monilenet_40_base() -> MobileNet:
+def mobilenet_40_base() -> MobileNet:
     """MobileNet backbone"""
     return MobileNet(cfg=MobileNetConfig({"width_mult": 4}))

--- a/src/deepaudiox/modules/baseclasses.py
+++ b/src/deepaudiox/modules/baseclasses.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from deepaudiox.dtos.dataset_items import AudioPrediction
+from deepaudiox.schemas.predictions import AudioPrediction
 from deepaudiox.utils.decorators import eval_mode
 
 

--- a/src/deepaudiox/modules/baseclasses.py
+++ b/src/deepaudiox/modules/baseclasses.py
@@ -14,6 +14,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from deepaudiox.dtos.dataset_items import AudioPrediction
+from deepaudiox.utils.decorators import eval_mode
 
 
 class BaseAudioClassifier(nn.Module, ABC):
@@ -47,6 +48,12 @@ class BaseAudioClassifier(nn.Module, ABC):
     def predict(self, x: torch.Tensor) -> dict[str, np.ndarray]:
         """Compute predicted class and posterior probabilities.
 
+        This is a low-level method that does not manage model mode or gradient
+        context. The caller is responsible for calling ``model.eval()`` and
+        wrapping with ``torch.no_grad()`` or ``torch.inference_mode()`` as needed.
+        For end-to-end inference with automatic mode management, use
+        ``inference_on_waveform`` or ``inference_on_file`` instead.
+
         Args:
             x (torch.Tensor): Input waveforms of shape (B, T), where T is the number of audio samples.
 
@@ -57,15 +64,15 @@ class BaseAudioClassifier(nn.Module, ABC):
             >>> import torch
             >>> from deepaudiox import AudioClassifier
             >>> model = AudioClassifier(num_classes=10, backbone="beats", sample_rate=16_000, pretrained=True)
+            >>> model.eval()
             >>> waveforms = torch.randn(2, 5 * 16_000)
-            >>> outputs = model.predict(waveforms)
+            >>> with torch.no_grad():
+            ...     outputs = model.predict(waveforms)
         """
         if x.dim() == 1:
             x = x.unsqueeze(0)
 
-        self.eval()
-        with torch.no_grad():
-            logits = self.forward(x)
+        logits = self.forward(x)
         posteriors = F.softmax(logits, dim=1)
         max_posteriors = posteriors.max(dim=1)
 
@@ -75,6 +82,8 @@ class BaseAudioClassifier(nn.Module, ABC):
             "logits": logits.numpy(force=True),
         }
 
+    @torch.inference_mode()
+    @eval_mode
     def inference_on_waveform(
         self,
         x: torch.Tensor | np.ndarray,
@@ -86,7 +95,7 @@ class BaseAudioClassifier(nn.Module, ABC):
         """Get prediction on a waveform.
 
         Args:
-            x (torch.Tensor | np.ndarray): Input waveform to be used for inference. Accepts shape (T,) or (1, T).
+            x (torch.Tensor | np.ndarray): Input waveform to be used for inference. Accepts shape (T,).
             sample_rate (int): Sampling rate of audio sample.
             class_mapping (dict[str, int]): Class-to-index mapping that is used by the model.
             segment_duration (float | None): Optional segment duration in seconds for segment-level inference.
@@ -117,8 +126,15 @@ class BaseAudioClassifier(nn.Module, ABC):
         """
         index_to_class = {idx: cl for cl, idx in class_mapping.items()}
 
+        # Convert to tensor if input is a np.ndarray
         if isinstance(x, np.ndarray):
             x = torch.from_numpy(x)
+
+        if x.ndim != 1:
+            raise ValueError(
+                f"Expected a 1-D waveform tensor of shape (T,), got shape {tuple(x.shape)}. "
+                "If you have a batched input, loop over samples and call this method individually."
+            )
 
         device = next(self.parameters()).device
         x = x.to(device)
@@ -143,19 +159,17 @@ class BaseAudioClassifier(nn.Module, ABC):
 
             # Create batches of segments and run inference
             batch_segments = batch_segments.view(-1, segment_len)
-            y_preds_batches, posteriors_batches, logits_batches = [], [], []
+            y_preds_batches, posteriors_batches = [], []
 
             for start in range(0, batch_segments.size(0), batch_size):
                 batch = batch_segments[start : start + batch_size]
                 batch_inference = self.predict(batch)
                 y_preds_batches.append(batch_inference["y_preds"])
                 posteriors_batches.append(batch_inference["posteriors"])
-                logits_batches.append(batch_inference["logits"])
 
             inference = {
                 "y_preds": np.concatenate(y_preds_batches),
                 "posteriors": np.concatenate(posteriors_batches),
-                "logits": np.concatenate(logits_batches),
             }
 
             # Accumulate segment-level labels

--- a/src/deepaudiox/modules/constructors.py
+++ b/src/deepaudiox/modules/constructors.py
@@ -8,7 +8,8 @@ from deepaudiox.modules.backbones import BACKBONES
 from deepaudiox.modules.baseclasses import BaseAudioClassifier, BaseBackbone, BasePooling
 from deepaudiox.modules.classifier.classifier import MLPHead
 from deepaudiox.modules.pooling import GAP, POOLING
-from deepaudiox.utils.downloader import BackboneName, Downloader
+from deepaudiox.schemas.types import BackboneName
+from deepaudiox.utils.downloader import Downloader
 from deepaudiox.utils.file_utils import load_checkpoint
 
 

--- a/src/deepaudiox/schemas/items.py
+++ b/src/deepaudiox/schemas/items.py
@@ -26,20 +26,3 @@ class AudioClassificationItem:
             "segment_idx": self.segment_idx,
             "feature": self.feature,
         }
-
-
-@dataclass
-class AudioPrediction:
-    final_label: str
-    final_posterior: float
-
-    segment_labels: list[str] | None = None
-    segment_posteriors: list[float] | None = None
-
-    def to_dict(self) -> dict:
-        return {
-            "final_label": self.final_label,
-            "final_posterior": self.final_posterior,
-            "segment_labels": self.segment_labels,
-            "segment_posteriors": self.segment_posteriors,
-        }

--- a/src/deepaudiox/schemas/predictions.py
+++ b/src/deepaudiox/schemas/predictions.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class AudioPrediction:
+    final_label: str
+    final_posterior: float
+
+    segment_labels: list[str] | None = None
+    segment_posteriors: list[float] | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "final_label": self.final_label,
+            "final_posterior": self.final_posterior,
+            "segment_labels": self.segment_labels,
+            "segment_posteriors": self.segment_posteriors,
+        }

--- a/src/deepaudiox/schemas/types.py
+++ b/src/deepaudiox/schemas/types.py
@@ -1,0 +1,4 @@
+from typing import Literal
+
+BackboneName = Literal["beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "mobilenet_40_as"]
+"""Supported pretrained backbone names."""

--- a/src/deepaudiox/utils/decorators.py
+++ b/src/deepaudiox/utils/decorators.py
@@ -1,0 +1,44 @@
+import functools
+from collections.abc import Callable
+from typing import TypeVar, cast
+
+F = TypeVar("F", bound=Callable)
+
+
+def eval_mode(method: F) -> F:
+    """Decorator that runs a method in evaluation mode and restores the original training state afterward.
+
+    Calls ``self.eval()`` before the method executes and restores the model to
+    training mode via ``self.train()`` in a ``finally`` block if the model was
+    training prior to the call. This guarantees the model state is always
+    restored, even if the method raises an exception.
+
+    Intended for use on inference methods of ``torch.nn.Module`` subclasses
+    where eval mode (disabled dropout, frozen BatchNorm statistics) is required
+    but the caller should not be responsible for managing model state.
+
+    Args:
+        method (Callable): The instance method to wrap.
+
+    Returns:
+        Callable: The wrapped method with automatic eval/train mode management.
+
+    Example:
+        >>> from deepaudiox.utils.decorators import eval_mode
+        >>> class MyModel(nn.Module):
+        ...     @eval_mode
+        ...     def predict(self, x):
+        ...         return self.forward(x)
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        was_training = self.training
+        self.eval()
+        try:
+            return method(self, *args, **kwargs)
+        finally:
+            if was_training:
+                self.train()
+
+    return cast(F, wrapper)

--- a/src/deepaudiox/utils/downloader.py
+++ b/src/deepaudiox/utils/downloader.py
@@ -1,12 +1,10 @@
 from pathlib import Path
-from typing import Literal
 
 import requests
 from platformdirs import user_cache_dir
 from tqdm import tqdm
 
-BackboneName = Literal["beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "mobilenet_40_as"]
-"""Supported pretrained backbone names."""
+from deepaudiox.schemas.types import BackboneName
 
 # Repository URL where the pretrained backbone models are hosted
 BACKBONE_REPO_URL = "https://github.com/magcil/pretrained-ssl-audio-backbones/raw/refs/heads/main/models/"

--- a/tests/test_deepaudiox.py
+++ b/tests/test_deepaudiox.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 import deepaudiox as dax
+from deepaudiox.modules.backbones import BACKBONES
 from deepaudiox.modules.classifier.classifier import MLPHead
 from deepaudiox.utils.training_utils import (
     get_class_mapping_from_dir,
@@ -106,7 +107,7 @@ def test_dataset_segmentation(segment_duration):
 
 @pytest.mark.parametrize("input_tensor", [torch.randn(1, 16000)])
 def test_beats_backbone(input_tensor):
-    backbone = dax.BACKBONES["beats"]()
+    backbone = BACKBONES["beats"]()
 
     output = backbone.forward_pipeline(input_tensor)
     assert output.shape == (1, 48, 768)
@@ -114,7 +115,7 @@ def test_beats_backbone(input_tensor):
 
 @pytest.mark.parametrize("input_tensor", [torch.randn(1, 32000)])
 def test_passt_backbone(input_tensor):
-    passt = dax.BACKBONES["passt"]()
+    passt = BACKBONES["passt"]()
 
     output = passt.forward_pipeline(input_tensor)
     print(output.shape)
@@ -137,7 +138,7 @@ def test_mlp_head(input_tensor, hidden_layers):
 @pytest.mark.parametrize("freeze_backbone", [True, False])
 @pytest.mark.parametrize("pretrained", [True, False])
 def test_backbone_constructor(backbone, pretrained, freeze_backbone, pooling, x):
-    backbone_constructor = dax.BackboneConstructor(
+    backbone_constructor = dax.Backbone(
         backbone=backbone, pretrained=pretrained, freeze_backbone=freeze_backbone, pooling=pooling, sample_rate=16_000
     )
 
@@ -164,7 +165,7 @@ def test_backbone_constructor(backbone, pretrained, freeze_backbone, pooling, x)
 @pytest.mark.parametrize("freeze_backbone", [True, False])
 @pytest.mark.parametrize("pretrained", [True, False])
 def test_model_construction(input_tensor, num_classes, backbone, pooling, freeze_backbone, pretrained):
-    model = dax.AudioClassifierConstructor(
+    model = dax.AudioClassifier(
         num_classes=num_classes,
         backbone=backbone,
         pooling=pooling,
@@ -198,7 +199,7 @@ def test_training_loop():
         root_dir=str(VALIDATION_DIR), sample_rate=16000, class_mapping=class_mapping
     )
 
-    model = dax.AudioClassifierConstructor(
+    model = dax.AudioClassifier(
         num_classes=5,
         backbone="beats",
         pooling="gap",
@@ -241,7 +242,7 @@ def test_evaluation_loop():
         root_dir=str(TEST_DIR), sample_rate=16000, class_mapping=class_mapping
     )
 
-    model = dax.AudioClassifierConstructor(
+    model = dax.AudioClassifier(
         num_classes=5,
         backbone="beats",
         pooling="gap",
@@ -280,7 +281,7 @@ def test_inference(path_to_test_file: str):
     path_to_checkpoint = Path(__file__).resolve().parents[1] / "testing_checkpoint.pt"
     path_wav = Path(__file__).resolve().parents[1] / path_to_test_file
 
-    model = dax.AudioClassifierConstructor(
+    model = dax.AudioClassifier(
         num_classes=5,
         backbone="beats",
         pooling="gap",
@@ -297,7 +298,7 @@ def test_inference(path_to_test_file: str):
 
     # Inference on the whole audio file
     inference = model.inference_on_file(path=path_wav, class_mapping=class_mapping, sample_rate=16_000)
-    
+
     final_label = path_wav.parent.name
 
     assert inference["final_label"] == final_label

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "deepaudio-x"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "librosa" },


### PR DESCRIPTION
### Summary

This branch addresses a series of code quality, efficiency, and API clarity improvements across the inference pipeline, training loop, module structure, and public API surface. It Closes #56 

#### Inference (commit [9f59d73](https://github.com/magcil/deepaudio-x/commit/9f59d73d65ccbc598bd375c200433a0acb3150af))

- `predict()`: is now a pure low-level method — it no longer manages eval() mode or gradient context. The docstring explicitly states the caller is responsible.
- `inference_on_waveform()`: is decorated with `@torch.inference_mode()` and `@eval_mode` to handle the inference procedure more effectively, i.e., `inference_mode` if more efficient than the `torch.no_grad()` and `eval_mode` guarantees the model's training status stays consistent with the state before calling the method.

#### Evaluator (commit [0c005ee](https://github.com/magcil/deepaudio-x/commit/0c005ee810c0a7b4dbdb32a50ff7536f8be11656)

- Fixed O(n^2) `np.concatenate` memory allocate with multiple calls with the evaluation loop.
- Added `@torch.inference_mode()` decorator replace the `torch.no_grad()` content manager

#### Trainer (commit [da75933](https://github.com/magcil/deepaudio-x/commit/da75933e4f1e9ce9b49fa9608043a504fc9a1c62))

- `train()` is decomposed intro three sub-methods: `train.step()`, `val_step()`, and `epoch_step()`, allowing users to build custom training loops around `epoch_step()` while maintaining backward compatability with the existing codebase.

#### Module structure (commit [05290dd](https://github.com/magcil/deepaudio-x/commit/05290dd687df66f93202d87f0234fcfb85623817))

- Renamed `dtos/` → `schemas/` and `split dataset_items.py` into `items.py`, `predictions.py`, and `types.py`.
- `BackboneName` moved to `schemas/types.py` to eliminate the circular import between `downloader.py` and `backbones/__init__.py`.
- Fixed typo: `monilenet_*` → `mobilenet_*` in backbone registry.
- Suppressed `FutureWarning` from deprecated `torch.nn.utils.weight_norm `in BEATs backbone instantiation.

#### Public API

- Removed internal names (`AudioClassifierConstructor`, `BackboneConstructor`, `BACKBONES`, `POOLING`) from `__all__`.
- User-facing aliases `AudioClassifier` and `Backbone` are now the only exported model constructors.

Code checked with ruff and tests passing, locally. Please check these changes. Waiting for responses / suggestions!