### PR TITLE
58 add architecture info on audioclassifier and backbones and expose available backbones and pooling methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,24 @@ We welcome contributions of all kinds. If you want to improve DeepAudioX, there 
   `deepaudiox.modules.pooling`.
 - **Improve the library**: Optimize performance, fix bugs, enhance documentation, or add tests.
 
+## Development Setup
+
+Clone the repository and install all dependencies (including dev tools) using `uv`:
+
+```bash
+git clone https://github.com/magcil/deepaudio-x.git
+cd deepaudio-x
+uv sync
+```
+
+This installs the package in editable mode along with `pytest` and `ruff`.
+
+## Running Tests
+
+```bash
+uv run pytest -v
+```
+
 ## General Guidelines
 
 1. Open an issue to discuss major changes before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/deepaudio-x.svg?cacheSeconds=300)](https://pypi.org/project/deepaudio-x/)
 [![License](https://img.shields.io/github/license/magcil/deepaudio-x.svg)](https://github.com/magcil/deepaudio-x/blob/main/LICENSE)
 [![Run Tests](https://github.com/magcil/deepaudio-x/actions/workflows/tests.yml/badge.svg)](https://github.com/magcil/deepaudio-x/actions/workflows/tests.yml)
+[![Publish to PyPI](https://github.com/magcil/deepaudio-x/actions/workflows/publish.yml/badge.svg)](https://github.com/magcil/deepaudio-x/actions/workflows/publish.yml)
 
 
 <p align="left">
@@ -93,7 +94,7 @@ You can load the dataset as follows:
 
 ```python
 from deepaudiox import audio_classification_dataset_from_dir
-from deepaudiox.utils.training_utils import get_class_mapping_from_dir
+from deepaudiox import get_class_mapping_from_dir
 
 # Define a class mapping
 class_mapping = get_class_mapping_from_dir(root_dir="path/to/data")
@@ -363,6 +364,9 @@ import torch
 
 from deepaudiox import Evaluator
 
+# Load model
+classifier.load_state_dict(torch.load("checkpoint.pt"))
+
 # Initialize evaluator
 evaluator = Evaluator(
     test_dset=test_dataset,
@@ -372,8 +376,6 @@ evaluator = Evaluator(
     num_workers=4
 )
 
-# Load model
-classifier.load_state_dict(torch.load("checkpoint.pt"))
 
 # Run evaluation
 evaluator.evaluate()
@@ -494,13 +496,6 @@ The library is designed to scale from quick experiments to research and producti
 
 ---
 
-## Project Status
-
-🚧 This project is under active development.
-
-APIs may evolve, but backward compatibility will be considered once a stable release is reached.
-
----
 
 ## Attribution
 
@@ -529,8 +524,6 @@ If you use this library in academic work, please cite:
 
 ## Contributing
 
-Contributions are welcome!
-
-Please open an issue to discuss major changes before submitting a pull request.
+Contributions are welcome! Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to set up the development environment, run tests, and submit changes.
 
 ---

--- a/README.md
+++ b/README.md
@@ -335,6 +335,13 @@ trainer = Trainer(
 trainer.train()
 ```
 
+> **Note:** The checkpoint saved at `path_to_checkpoint` contains both the model weights and the architecture config (backbone, pooling, num_classes, etc.). You can restore the full model in one line:
+> ```python
+> from deepaudiox import AudioClassifier
+> model = AudioClassifier.from_checkpoint("checkpoint.pt")
+> print(model.config)  # {"backbone": "beats", "pooling": "gap", ...}
+> ```
+
 ### Trainer Parameters
 
 - `train_dset`: Training dataset (AudioClassificationDataset)
@@ -360,12 +367,10 @@ trainer.train()
 Evaluate your trained classifier on a test dataset using the `Evaluator` class:
 
 ```python
-import torch
+from deepaudiox import AudioClassifier, Evaluator
 
-from deepaudiox import Evaluator
-
-# Load model
-classifier.load_state_dict(torch.load("checkpoint.pt"))
+# Load model with architecture and weights restored from checkpoint
+classifier = AudioClassifier.from_checkpoint("checkpoint.pt")
 
 # Initialize evaluator
 evaluator = Evaluator(

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -44,7 +44,7 @@ audio classifier:
 
    from deepaudiox import AudioClassifier, Evaluator, Trainer
    from deepaudiox import audio_classification_dataset_from_dir
-   from deepaudiox.utils.training_utils import get_class_mapping_from_dir
+   from deepaudiox import get_class_mapping_from_dir
 
    # 1) Build a dataset from a folder structure of class subdirectories
    class_mapping = get_class_mapping_from_dir(root_dir="path/to/data")
@@ -85,52 +85,3 @@ audio classifier:
 
    evaluator.evaluate()
 
-Supported backbones & pooling
------------------------------
-
-DeepAudio-X supports the following backbones and pooling methods:
-
-Backbones
-~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 35 50
-
-   * - Name
-     - Description
-     - Notes
-   * - beats
-     - BEATs backbone
-     - Transformer pretrained on AudioSet
-   * - passt
-     - PaSST backbone
-     - Transformer pretrained on AudioSet
-
-Pooling
-~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 35 50
-
-   * - Name
-     - Description
-     - Notes
-   * - gap
-     - Global Average Pooling
-     - Fast baseline
-   * - simpool
-     - Simple Pooling
-     - Strong attentive pooling
-   * - ep
-     - Efficient Probing
-     - Efficient attention pooling
-
-References
-----------
-
-- BEATs: `Audio Pre-Training with Acoustic Tokenizers <https://arxiv.org/abs/2212.09058>`_
-- PaSST: `Efficient Training of Audio Transformers with Patchout <https://arxiv.org/abs/2110.05069>`_
-- SimPool: `Keep It SimPool: Who Said Supervised Transformers Suffer from Attention Deficit? <https://arxiv.org/abs/2309.06891>`_
-- EP: `Attention, Please! Revisiting Attentive Probing Through the Lens of Efficiency <https://arxiv.org/abs/2506.10178>`_

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -40,8 +40,6 @@ audio classifier:
 
 .. code-block:: python
 
-   import torch
-
    from deepaudiox import AudioClassifier, Evaluator, Trainer
    from deepaudiox import audio_classification_dataset_from_dir
    from deepaudiox import get_class_mapping_from_dir
@@ -74,7 +72,7 @@ audio classifier:
 
    trainer.train()
 
-   classifier.load_state_dict(torch.load("checkpoint.pt"))  # Load model
+   classifier = AudioClassifier.from_checkpoint("checkpoint.pt")  # Load model with config restored
 
    # 4) Evaluate on a test set
    evaluator = Evaluator(

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -24,29 +24,46 @@ Methods for building datasets and class mappings from directories or label lists
 Models & Backbones
 ------------------
 
-Constructors and registries for initializing classifiers, backbones, and pooling.
+Constructors for initializing classifiers and backbones.
 
-.. autoclass:: AudioClassifierConstructor
+.. autoclass:: deepaudiox.modules.constructors.AudioClassifierConstructor
    :members:
-   :exclude-members: __init__
+   :special-members: __init__
    :undoc-members:
 
-.. autoclass:: BackboneConstructor
+   .. note:: Available as ``deepaudiox.AudioClassifier``.
+
+.. autoclass:: deepaudiox.modules.constructors.BackboneConstructor
    :members:
-   :exclude-members: __init__
+   :special-members: __init__
    :undoc-members:
 
-.. data:: BACKBONES
-   :annotation: = dict
+   .. note:: Available as ``deepaudiox.Backbone``.
 
-.. data:: POOLING
-   :annotation: = dict
+Supported Backbones & Pooling
+-----------------------------
 
-.. autoclass:: AudioClassifier
-   :noindex:
+Type aliases and runtime constants for valid backbone and pooling names.
 
-.. autoclass:: Backbone
-   :noindex:
+.. data:: AVAILABLE_BACKBONES
+   :annotation: = ("beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "mobilenet_40_as")
+
+   Supported pretrained backbone names available at runtime.
+
+.. data:: AVAILABLE_POOLING
+   :annotation: = ("gap", "simpool", "ep")
+
+   Supported pooling layer names available at runtime.
+
+.. data:: BackboneName
+
+   Type alias: ``Literal["beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "mobilenet_40_as"]``.
+   Use for type-annotated code.
+
+.. data:: PoolingName
+
+   Type alias: ``Literal["gap", "simpool", "ep"]``.
+   Use for type-annotated code.
 
 Training & Evaluation
 ---------------------
@@ -55,12 +72,12 @@ Interfaces for training models and evaluating performance on held-out data.
 
 .. autoclass:: Trainer
    :members:
-   :exclude-members: __init__
+   :special-members: __init__
    :undoc-members:
 
 .. autoclass:: Evaluator
    :members:
-   :exclude-members: __init__
+   :special-members: __init__
    :undoc-members:
 
 Base Classes & Inference
@@ -78,9 +95,7 @@ Full Paths
 The API re-exports the following symbols. If you prefer importing from the original modules, use these paths:
 
 - ``AudioClassifier`` -> ``deepaudiox.modules.constructors.AudioClassifierConstructor``
-- ``AudioClassifierConstructor`` -> ``deepaudiox.modules.constructors.AudioClassifierConstructor``
 - ``Backbone`` -> ``deepaudiox.modules.constructors.BackboneConstructor``
-- ``BackboneConstructor`` -> ``deepaudiox.modules.constructors.BackboneConstructor``
 - ``AudioClassificationDataset`` -> ``deepaudiox.datasets.audio_classification_dataset.AudioClassificationDataset``
 - ``audio_classification_dataset_from_dir`` -> ``deepaudiox.datasets.audio_classification_dataset.audio_classification_dataset_from_dir``
 - ``audio_classification_dataset_from_dictionary`` -> ``deepaudiox.datasets.audio_classification_dataset.audio_classification_dataset_from_dictionary``
@@ -88,5 +103,7 @@ The API re-exports the following symbols. If you prefer importing from the origi
 - ``get_class_mapping_from_list`` -> ``deepaudiox.utils.training_utils.get_class_mapping_from_list``
 - ``Trainer`` -> ``deepaudiox.loops.trainer.Trainer``
 - ``Evaluator`` -> ``deepaudiox.loops.evaluator.Evaluator``
-- ``BACKBONES`` -> ``deepaudiox.modules.backbones.BACKBONES``
-- ``POOLING`` -> ``deepaudiox.modules.pooling.POOLING``
+- ``BackboneName`` -> ``deepaudiox.schemas.types.BackboneName``
+- ``PoolingName`` -> ``deepaudiox.schemas.types.PoolingName``
+- ``AVAILABLE_BACKBONES`` -> ``deepaudiox.__init__.AVAILABLE_BACKBONES``
+- ``AVAILABLE_POOLING`` -> ``deepaudiox.__init__.AVAILABLE_POOLING``

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -14,6 +14,26 @@ How You Can Contribute
   ``deepaudiox.modules.pooling``.
 - **Improve the library**: Optimize performance, fix bugs, enhance documentation, or add tests.
 
+Development Setup
+-----------------
+
+Clone the repository and install all dependencies (including dev tools) using `uv`:
+
+.. code-block:: bash
+
+   git clone https://github.com/magcil/deepaudio-x.git
+   cd deepaudio-x
+   uv sync
+
+This installs the package in editable mode along with ``pytest`` and ``ruff``.
+
+Running Tests
+-------------
+
+.. code-block:: bash
+
+   uv run pytest -v
+
 General Guidelines
 ------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,10 @@ DeepAudio-X
    :target: https://github.com/magcil/deepaudio-x/actions/workflows/tests.yml
    :alt: Tests
 
+.. image:: https://github.com/magcil/deepaudio-x/actions/workflows/publish.yml/badge.svg
+   :target: https://github.com/magcil/deepaudio-x/actions/workflows/publish.yml
+   :alt: Publish
+
 DeepAudio-X is a self-supervised audio toolkit for audio classification and related
 tasks.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,33 +6,62 @@ This section provides instructions on how to install DeepAudio-X.
 Requirements
 ------------
 
-DeepAudio-X requires Python 3.11, 3.12 or 3.13. It is recommended to use a virtual environment. For example, you can use miniconda or venv.
+DeepAudio-X requires Python 3.11, 3.12 or 3.13. It is recommended to use a virtual environment.
 
-Example with venv:
+With venv:
 
 .. code-block:: bash
 
    python3 -m venv deepaudiox-env
    source deepaudiox-env/bin/activate  # On Windows use `deepaudiox-env\Scripts\activate`
 
-Or with miniconda:
+With miniconda:
 
 .. code-block:: bash
 
    conda create -n deepaudiox-env python=3.13
    conda activate deepaudiox-env
 
+With `uv <https://docs.astral.sh/uv/getting-started/installation/>`_ (recommended):
+
+.. code-block:: bash
+
+   uv venv --python 3.13
+   source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+
 PyPI
 ----
 
-DeepAudio-X is available on PyPI and can be installed with pip:
+DeepAudio-X is available on PyPI. Install with pip:
 
 .. code-block:: bash
 
    pip install deepaudio-x
 
+Or with uv:
+
+.. code-block:: bash
+
+   uv pip install deepaudio-x
+
+.. note::
+
+   The PyTorch version pulled from PyPI may require a newer NVIDIA driver than
+   what is installed on your system. After installation, verify that CUDA is available:
+
+   .. code-block:: python
+
+      import torch
+      print(torch.cuda.is_available())   # True if GPU is available
+      print(torch.version.cuda)          # CUDA version PyTorch was built for
+
+   If ``False`` is returned, either update your driver from
+   `nvidia.com <https://www.nvidia.com/Download/index.aspx>`_ or downgrade PyTorch
+   to a version compatible with your driver. See
+   `pytorch.org <https://pytorch.org/get-started/locally/>`_ to find the right build.
+
 Source
------------------------------------------
+------
 
 If you want a pre-release version, clone the repo and use `uv sync` to install
 dependencies from `pyproject.toml` and `uv.lock`. For installing uv itself, see
@@ -43,3 +72,9 @@ the `uv installation guide <https://docs.astral.sh/uv/getting-started/installati
    git clone https://github.com/magcil/deepaudio-x.git
    cd deepaudio-x
    uv sync
+
+Verify the installation:
+
+.. code-block:: bash
+
+   python -c "import deepaudiox; print(deepaudiox.__version__)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepaudio-x"
-version = "0.4.1"
+version = "0.4.2"
 description = "DeepAudio-X: Self-supervised audio toolkit for audio classification and beyond."
 authors = [
   { name = "Christos Nikou", email = "chrisnick92@gmail.com" }, 

--- a/src/deepaudiox/__init__.py
+++ b/src/deepaudiox/__init__.py
@@ -17,10 +17,17 @@ from deepaudiox.modules.constructors import (  # noqa: F401
 from deepaudiox.modules.constructors import (
     BackboneConstructor as Backbone,
 )
+from deepaudiox.schemas.types import BackboneName, PoolingName  # noqa: F401
 from deepaudiox.utils.training_utils import (  # noqa: F401
     get_class_mapping_from_dir,
     get_class_mapping_from_list,
 )
+
+AVAILABLE_BACKBONES: tuple[str, ...] = ("beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "mobilenet_40_as")
+"""Supported pretrained backbone names available at runtime."""
+
+AVAILABLE_POOLING: tuple[str, ...] = ("gap", "simpool", "ep")
+"""Supported pooling layer names available at runtime."""
 
 __all__ = [
     "AudioClassifier",
@@ -30,6 +37,10 @@ __all__ = [
     "audio_classification_dataset_from_dir",
     "Evaluator",
     "Trainer",
+    "BackboneName",
+    "PoolingName",
+    "AVAILABLE_BACKBONES",
+    "AVAILABLE_POOLING",
     "get_class_mapping_from_dir",
     "get_class_mapping_from_list",
 ]

--- a/src/deepaudiox/__init__.py
+++ b/src/deepaudiox/__init__.py
@@ -2,7 +2,7 @@
 This page provides the core API reference for DeepAudioX.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from deepaudiox.datasets.audio_classification_dataset import (  # noqa: F401
     AudioClassificationDataset,

--- a/src/deepaudiox/callbacks/checkpointer.py
+++ b/src/deepaudiox/callbacks/checkpointer.py
@@ -54,7 +54,13 @@ class Checkpointer(BaseCallback):
 
             try:
                 self.path_to_checkpoint.parent.mkdir(parents=True, exist_ok=True)
-                torch.save(trainer.model.state_dict(), self.path_to_checkpoint)
+                torch.save(
+                    {
+                        "state_dict": trainer.model.state_dict(),
+                        "config": getattr(trainer.model, "config", {}),
+                    },
+                    self.path_to_checkpoint,
+                )
                 self.logger.info(f"[CHECKPOINTER] Checkpoint saved successfully at: {self.path_to_checkpoint}")
             except PermissionError:
                 self.logger.info(f"[CHECKPOINTER] Permission denied: cannot write to {self.path_to_checkpoint}")

--- a/src/deepaudiox/modules/constructors.py
+++ b/src/deepaudiox/modules/constructors.py
@@ -82,7 +82,9 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
         backbone (BaseBackbone): Backbone model for feature extraction.
         pooling (BasePooling): Pooling layer applied to the backbone feature map.
         norm_p (float or None): Optional Lp normalization applied after pooling.
-        out_dim (int): Dimension of the backbone model feature map
+        out_dim (int): Dimension of the backbone model feature map.
+        config (dict): Constructor arguments used to build this model. Used by
+            ``from_checkpoint`` to reconstruct the model from a saved checkpoint.
     """
 
     def __init__(
@@ -117,6 +119,16 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
             ... )
         """
         super().__init__()
+
+        self.config = {
+            "backbone": backbone if isinstance(backbone, str) else None,
+            "pooling": pooling if isinstance(pooling, str) else None,
+            "pretrained": pretrained,
+            "freeze_backbone": freeze_backbone,
+            "sample_rate": sample_rate,
+            "norm_p": norm_p,
+        }
+
         self.backbone = self._resolve_backbone(
             backbone=backbone, pretrained=pretrained, sample_rate=sample_rate
         )  # Resolve backbone
@@ -131,6 +143,31 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
         if freeze_backbone:
             for p in self.backbone.parameters():
                 p.requires_grad = False
+
+    @classmethod
+    def from_checkpoint(cls, path: str) -> "BackboneConstructor":
+        """Load a BackboneConstructor from a checkpoint saved by the Checkpointer.
+
+        Args:
+            path (str): Path to the checkpoint file.
+
+        Returns:
+            BackboneConstructor: Model with weights and config restored.
+
+        Example:
+            >>> from deepaudiox import Backbone
+            >>> backbone = Backbone.from_checkpoint("checkpoint.pt")
+            >>> print(backbone.config)
+        """
+        ckpt = torch.load(path, weights_only=False)
+        if ckpt["config"].get("backbone") is None:
+            raise ValueError(
+                "Cannot reconstruct model from checkpoint: a custom BaseBackbone instance was used. "
+                "Instantiate the model manually and call model.load_state_dict(torch.load(path)['state_dict'])."
+            )
+        model = cls(**ckpt["config"])
+        model.load_state_dict(ckpt["state_dict"])
+        return model
 
     def extract_features(self, waveforms: torch.Tensor) -> torch.Tensor:
         """Extract backbone-specific features from raw waveforms.
@@ -192,8 +229,10 @@ class AudioClassifierConstructor(BaseAudioClassifier, BackbonePoolingResolverMix
     """Classifier model using a backbone for feature extraction.
 
     Attributes:
-        backbone (BaseBackboneConstructor): Backbone model with optional pooling method.
+        backbone_constructor (BackboneConstructor): Backbone model with optional pooling method.
         classifier (MLPHead): Classifier head for final predictions.
+        config (dict): Constructor arguments used to build this model. Used by
+            ``from_checkpoint`` to reconstruct the model from a saved checkpoint.
     """
 
     def __init__(
@@ -240,6 +279,18 @@ class AudioClassifierConstructor(BaseAudioClassifier, BackbonePoolingResolverMix
         """
         super().__init__()
 
+        self.config = {
+            "backbone": backbone if isinstance(backbone, str) else None,
+            "pooling": pooling if isinstance(pooling, str) else None,
+            "num_classes": num_classes,
+            "pretrained": pretrained,
+            "freeze_backbone": freeze_backbone,
+            "sample_rate": sample_rate,
+            "classifier_hidden_layers": classifier_hidden_layers,
+            "activation": activation,
+            "apply_batch_norm": apply_batch_norm,
+        }
+
         self.backbone_constructor = BackboneConstructor(
             backbone=backbone,
             pretrained=pretrained,
@@ -255,6 +306,31 @@ class AudioClassifierConstructor(BaseAudioClassifier, BackbonePoolingResolverMix
             activation=activation,
             apply_batch_norm=apply_batch_norm,
         )
+
+    @classmethod
+    def from_checkpoint(cls, path: str) -> "AudioClassifierConstructor":
+        """Load an AudioClassifierConstructor from a checkpoint saved by the Checkpointer.
+
+        Args:
+            path (str): Path to the checkpoint file.
+
+        Returns:
+            AudioClassifierConstructor: Model with weights and config restored.
+
+        Example:
+            >>> from deepaudiox import AudioClassifier
+            >>> model = AudioClassifier.from_checkpoint("checkpoint.pt")
+            >>> print(model.config)
+        """
+        ckpt = torch.load(path, weights_only=False)
+        if ckpt["config"].get("backbone") is None:
+            raise ValueError(
+                "Cannot reconstruct model from checkpoint: a custom BaseBackbone instance was used. "
+                "Instantiate the model manually and call model.load_state_dict(torch.load(path)['state_dict'])."
+            )
+        model = cls(**ckpt["config"])
+        model.load_state_dict(ckpt["state_dict"])
+        return model
 
     def forward(self, x) -> torch.Tensor:
         """Forward pass through the classifier.

--- a/src/deepaudiox/modules/constructors.py
+++ b/src/deepaudiox/modules/constructors.py
@@ -8,7 +8,7 @@ from deepaudiox.modules.backbones import BACKBONES
 from deepaudiox.modules.baseclasses import BaseAudioClassifier, BaseBackbone, BasePooling
 from deepaudiox.modules.classifier.classifier import MLPHead
 from deepaudiox.modules.pooling import GAP, POOLING
-from deepaudiox.schemas.types import BackboneName
+from deepaudiox.schemas.types import BackboneName, PoolingName
 from deepaudiox.utils.downloader import Downloader
 from deepaudiox.utils.file_utils import load_checkpoint
 
@@ -58,13 +58,13 @@ class BackbonePoolingResolverMixin:
 
     def _resolve_pooling(
         self,
-        pooling: Literal["gap", "simpool", "ep"] | BasePooling,
+        pooling: PoolingName | BasePooling,
         out_dim: int,
     ) -> BasePooling:
         """Resolve pooling layer from literal, BasePooling instance, or None.
 
         Args:
-            pooling (Literal["gap", "simpool", "ep"] | BasePooling | None): Pooling layer name, instance, or None.
+            pooling (PoolingName | BasePooling | None): Pooling layer name, instance, or None.
             out_dim (int): Backbone output dimension used to configure pooling modules.
 
         Returns:
@@ -90,7 +90,7 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
         backbone: BackboneName | BaseBackbone,
         pretrained: bool = False,
         freeze_backbone: bool = False,
-        pooling: Literal["gap", "simpool", "ep"] | BasePooling | None = None,
+        pooling: PoolingName | BasePooling | None = None,
         sample_rate: int = 16_000,
         norm_p: float | None = None,
     ):
@@ -101,7 +101,7 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
                 Valid names are: "beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "mobilenet_40_as".
             pretrained (bool): Whether to load pretrained weights for the backbone.
             freeze_backbone (bool): Whether to freeze the backbone weights during training.
-            pooling (Literal["gap", "simpool", "ep"] | BasePooling | None): Optional pooling layer for aggregation.
+            pooling (PoolingName | BasePooling | None): Optional pooling layer for aggregation.
             sample_rate (int): Sample frequency for audio input.
             norm_p (float or None): Optional Lp norm applied after pooling. If pooling is None, GAP is used.
 
@@ -200,7 +200,7 @@ class AudioClassifierConstructor(BaseAudioClassifier, BackbonePoolingResolverMix
         self,
         num_classes: int,
         backbone: BackboneName | BaseBackbone,
-        pooling: Literal["gap", "simpool", "ep"] | BasePooling | None = None,
+        pooling: PoolingName | BasePooling | None = None,
         freeze_backbone: bool = False,
         sample_rate: int = 16000,
         classifier_hidden_layers: list[int] | None = None,
@@ -214,7 +214,7 @@ class AudioClassifierConstructor(BaseAudioClassifier, BackbonePoolingResolverMix
             num_classes (int): Number of output classes.
             backbone (BackboneName | BaseBackbone): Backbone model to use for feature extraction.
                 Valid names are: "beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "mobilenet_40_as".
-            pooling (Literal["gap", "simpool", "ep"] | BasePooling | None): Optional pooling layer to aggregate
+            pooling (PoolingName | BasePooling | None): Optional pooling layer to aggregate
                 features.
             freeze_backbone (bool): Whether to freeze the backbone weights during training.
             sample_rate (int): Sample frequency for audio input.

--- a/src/deepaudiox/schemas/types.py
+++ b/src/deepaudiox/schemas/types.py
@@ -2,3 +2,6 @@ from typing import Literal
 
 BackboneName = Literal["beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "mobilenet_40_as"]
 """Supported pretrained backbone names."""
+
+PoolingName = Literal["gap", "simpool", "ep"]
+"""Supported pooling layer names."""

--- a/tests/test_deepaudiox.py
+++ b/tests/test_deepaudiox.py
@@ -255,8 +255,7 @@ def test_evaluation_loop():
     )
 
     path_to_checkpoint = Path(__file__).resolve().parents[1] / "testing_checkpoint.pt"
-    state_dict = torch.load(path_to_checkpoint, map_location="cpu")
-    model.load_state_dict(state_dict)
+    model = dax.AudioClassifier.from_checkpoint(str(path_to_checkpoint))
 
     evaluator = dax.Evaluator(
         test_dset=test_dataset, model=model, num_workers=4, batch_size=16, class_mapping=class_mapping
@@ -281,18 +280,7 @@ def test_inference(path_to_test_file: str):
     path_to_checkpoint = Path(__file__).resolve().parents[1] / "testing_checkpoint.pt"
     path_wav = Path(__file__).resolve().parents[1] / path_to_test_file
 
-    model = dax.AudioClassifier(
-        num_classes=5,
-        backbone="beats",
-        pooling="gap",
-        freeze_backbone=True,
-        sample_rate=16000,
-        classifier_hidden_layers=None,
-        activation="relu",
-        apply_batch_norm=False,
-        pretrained=True,
-    )
-    model.load_state_dict(torch.load(path_to_checkpoint, map_location="cpu"))
+    model = dax.AudioClassifier.from_checkpoint(str(path_to_checkpoint))
 
     class_mapping = get_class_mapping_from_dir(str(TRAIN_DIR))
 

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "deepaudio-x"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "librosa" },


### PR DESCRIPTION
<h2>Summary</h2>
<p>
  This PR Closes #58 by surfacing architecture metadata on
  <code>AudioClassifier</code> and <code>Backbone</code> models, exposing runtime
  constants for available backbones and pooling methods, and improving the public
  API surface, documentation, and test coverage.
</p>

<h3>Checkpoint Architecture Persistence</h3>
<ul>
  <li>
    <code>AudioClassifierConstructor</code> and <code>BackboneConstructor</code>
    now store a <code>config</code> dict as a class attribute, capturing all
    constructor arguments (backbone name, pooling, num_classes, etc.)
  </li>
  <li>
    <code>Checkpointer</code> now saves
    <code>{"state_dict": ..., "config": {...}}</code> instead of a bare
    <code>state_dict</code>, so <code>.pt</code> files are self-describing.
  </li>
  <li>
    Both classes expose a <code>from_checkpoint(path)</code> classmethod that
    reconstructs the full model (architecture + weights) in one call — no need
    to manually re-specify constructor arguments.
  </li>
  <li>
    A clear <code>ValueError</code> is raised when attempting to load a
    checkpoint built with a custom <code>BaseBackbone</code> instance (which
    cannot be serialized by name).
  </li>
</ul>

<h3>Public API Additions</h3>
<ul>
  <li>
    Added <code>AVAILABLE_BACKBONES: tuple[str, ...]</code> and
    <code>AVAILABLE_POOLING: tuple[str, ...]</code> runtime constants to the
    top-level <code>deepaudiox</code> namespace for programmatic inspection.
  </li>
  <li>
    Added <code>PoolingName</code> type alias
    (<code>Literal["gap", "simpool", "ep"]</code>) to
    <code>schemas/types.py</code>, consistent with the existing
    <code>BackboneName</code>; replaced three inline <code>Literal</code>
    duplications in <code>constructors.py</code>.
  </li>
  <li>
    Removed internal registry dicts (<code>BACKBONES</code>,
    <code>POOLING</code>) and constructor class names
    (<code>AudioClassifierConstructor</code>, <code>BackboneConstructor</code>)
    from <code>__all__</code> — users interact only through the public aliases
    <code>AudioClassifier</code> and <code>Backbone</code>.
  </li>
</ul>

<h3>Documentation</h3>
<ul>
  <li>
    <strong>API Reference:</strong> Fixed <code>AudioClassifier</code> and
    <code>Backbone</code> rendering as "alias of..." by pointing
    <code>autoclass</code> directives to the original module paths; added
    <code>AVAILABLE_BACKBONES</code>, <code>AVAILABLE_POOLING</code>,
    <code>BackboneName</code>, <code>PoolingName</code> entries.
  </li>
  <li>
    <strong>Installation:</strong> Added <code>uv</code>-based environment setup
    alongside the existing <code>venv</code>/<code>conda</code> instructions.
  </li>
  <li>
    <strong>About:</strong> Removed stale "Supported backbones &amp; pooling"
    and "References" sections; updated code examples to use the public API.
  </li>
  <li>
    <strong>Contributing:</strong> Added development setup
    (<code>uv sync</code>) and test execution
    (<code>uv run pytest -v</code>) instructions.
  </li>
  <li>
    <strong>README:</strong> Updated training and evaluation examples to use
    <code>from_checkpoint</code>; added a note explaining that
    <code>.pt</code> checkpoints contain both weights and architecture config;
    added PyPI publish badge.
  </li>
</ul>

<h3>Tests</h3>
<ul>
  <li>
    Updated <code>test_evaluation_loop</code> and <code>test_inference</code>
    to use <code>AudioClassifier.from_checkpoint(...)</code> instead of
    manually calling <code>torch.load</code> + <code>load_state_dict</code>.
  </li>
</ul>
