### PR TITLE
60 add mps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ trainer = Trainer(
     batch_size=32,
     epochs=100,
     num_workers=4,
-    patience=20
+    patience=20,
+    device="cuda",  # "cuda", "mps" (Apple Silicon), or "cpu"
 )
 
 # Start training
@@ -354,13 +355,15 @@ trainer.train()
 - `patience`: Number of epochs with no improvement before early stopping (default: 15)
 - `num_workers`: Number of workers for data loading (default: 4)
 - `path_to_checkpoint`: Path to save the best model checkpoint (default: "checkpoint.pt")
+- `device`: Device to use for training — `"cuda"`, `"mps"` (Apple Silicon GPU), or `"cpu"` (default: `"cuda"`)
+- `device_index`: GPU index to use when `device="cuda"` and multiple GPUs are available (optional)
 
 ### Features
 
 - **Automatic Checkpointing**: Saves the best model based on validation loss
 - **Early Stopping**: Stops training when validation loss plateaus
 - **Progress Tracking**: Displays training progress with loss metrics
-- **Device Agnostic**: Automatically detects and uses GPU if available
+- **Device Selection**: Supports `"cuda"`, `"mps"` (Apple Silicon), and `"cpu"` via the `device` parameter
 
 ## Evaluate
 
@@ -378,7 +381,8 @@ evaluator = Evaluator(
     model=classifier,
     class_mapping=class_mapping,
     batch_size=32,
-    num_workers=4
+    num_workers=4,
+    device="cuda",  # "cuda", "mps" (Apple Silicon), or "cpu"
 )
 
 
@@ -398,7 +402,8 @@ posteriors = evaluator.state.posteriors  # Prediction probabilities
 - `class_mapping`: Dictionary mapping class names to IDs
 - `batch_size`: Number of samples per batch (default: 16)
 - `num_workers`: Number of workers for data loading (default: 4)
-- `device_index`: GPU device index to use (optional, auto-detects by default)
+- `device`: Device to use for evaluation — `"cuda"`, `"mps"` (Apple Silicon GPU), or `"cpu"` (default: `"cuda"`)
+- `device_index`: GPU index to use when `device="cuda"` and multiple GPUs are available (optional)
 
 ### Evaluation Results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepaudio-x"
-version = "0.4.2"
+version = "0.4.3"
 description = "DeepAudio-X: Self-supervised audio toolkit for audio classification and beyond."
 authors = [
   { name = "Christos Nikou", email = "chrisnick92@gmail.com" }, 

--- a/src/deepaudiox/__init__.py
+++ b/src/deepaudiox/__init__.py
@@ -2,7 +2,7 @@
 This page provides the core API reference for DeepAudioX.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 from deepaudiox.datasets.audio_classification_dataset import (  # noqa: F401
     AudioClassificationDataset,

--- a/src/deepaudiox/loops/evaluator.py
+++ b/src/deepaudiox/loops/evaluator.py
@@ -9,6 +9,7 @@ from deepaudiox.callbacks.console_logger import ConsoleLogger
 from deepaudiox.callbacks.reporter import Reporter
 from deepaudiox.datasets.audio_classification_dataset import AudioClassificationDataset
 from deepaudiox.modules.baseclasses import BaseAudioClassifier
+from deepaudiox.schemas.types import DeviceName
 from deepaudiox.utils.training_utils import get_device, get_logger, pad_collate_fn
 
 
@@ -50,6 +51,7 @@ class Evaluator:
         class_mapping: dict,
         batch_size: int = 16,
         num_workers: int = 4,
+        device: DeviceName = "cuda",
         device_index: int | None = None,
     ):
         """Initialize the Evaluator.
@@ -60,7 +62,10 @@ class Evaluator:
             class_mapping (dict): A mapping between class names and IDs.
             batch_size (int, optional): The batch size for Python Data Loaders. Defaults to 16.
             num_workers (int, optional): The number of workers for Python Data Loaders. Defaults to 4.
-            device_index (int | None): The GPU device index to use. If None, uses the default GPU if available.
+            device (DeviceName): The device to use for evaluation. One of ``"cuda"``, ``"mps"``, or ``"cpu"``.
+                Defaults to ``"cuda"``.
+            device_index (int | None): The GPU device index. Only applicable when ``device="cuda"``.
+                If ``None``, uses the default CUDA device.
 
         Example:
             >>> import torch
@@ -78,7 +83,7 @@ class Evaluator:
             >>> evaluator.evaluate()
         """
         self.state = State()
-        self.device = get_device(device_index=device_index)
+        self.device = get_device(device=device, device_index=device_index)
         self.class_mapping = class_mapping
 
         # Configure logger
@@ -90,7 +95,8 @@ class Evaluator:
             batch_size=batch_size,
             shuffle=False,
             num_workers=num_workers,
-            pin_memory=True,
+            pin_memory=self.device.type == "cuda",
+            persistent_workers=num_workers > 0,
             collate_fn=pad_collate_fn,
         )
 

--- a/src/deepaudiox/loops/trainer.py
+++ b/src/deepaudiox/loops/trainer.py
@@ -13,6 +13,7 @@ from deepaudiox.callbacks.console_logger import ConsoleLogger
 from deepaudiox.callbacks.early_stopper import EarlyStopper
 from deepaudiox.datasets.audio_classification_dataset import AudioClassificationDataset
 from deepaudiox.modules.baseclasses import BaseAudioClassifier
+from deepaudiox.schemas.types import DeviceName
 from deepaudiox.utils.training_utils import get_device, get_logger, pad_collate_fn, random_split_audio_dataset
 
 
@@ -72,6 +73,7 @@ class Trainer:
         num_workers: int = 4,
         batch_size: int = 16,
         path_to_checkpoint: str = "checkpoint.pt",
+        device: DeviceName = "cuda",
         device_index: int | None = None,
     ):
         """Initialize the Trainer.
@@ -91,7 +93,10 @@ class Trainer:
             num_workers (int, optional): The number of workers for Python Data Loaders. Defaults to 4.
             batch_size (int, optional): The batch size for Python Data Loaders. Defaults to 16.
             path_to_checkpoint (str, optional): The path to the saved model checpoint. Defaults to "checkpoint.pt".
-            device_index (int | None): The GPU device index to use. If None, uses the default GPU if available.
+            device (DeviceName): The device to use for training. One of ``"cuda"``, ``"mps"``, or ``"cpu"``.
+                Defaults to ``"cuda"``.
+            device_index (int | None): The GPU device index. Only applicable when ``device="cuda"``.
+                If ``None``, uses the default CUDA device.
 
         Example:
             >>> from deepaudiox import AudioClassifier, Trainer
@@ -109,7 +114,7 @@ class Trainer:
         # Configure training state
         self.state = State()
         self.epochs = epochs
-        self.device = get_device(device_index=device_index)
+        self.device = get_device(device=device, device_index=device_index)
 
         # Configure logger
         self.logger = get_logger()
@@ -274,12 +279,15 @@ class Trainer:
             validation_dataset = validation_dset
 
         # Produce DataLoaders
+        pin_memory = self.device.type == "cuda"
+        persistent_workers = num_workers > 0
         train_dloader = DataLoader(
             train_dataset,
             batch_size=batch_size,
             shuffle=True,
             num_workers=num_workers,
-            pin_memory=True,
+            pin_memory=pin_memory,
+            persistent_workers=persistent_workers,
             collate_fn=pad_collate_fn,
         )
 
@@ -288,7 +296,8 @@ class Trainer:
             batch_size=batch_size,
             shuffle=False,
             num_workers=num_workers,
-            pin_memory=True,
+            pin_memory=pin_memory,
+            persistent_workers=persistent_workers,
             collate_fn=pad_collate_fn,
         )
 

--- a/src/deepaudiox/modules/backbones/passt/preprocess.py
+++ b/src/deepaudiox/modules/backbones/passt/preprocess.py
@@ -117,7 +117,7 @@ class AugmentMelSTFT(nn.Module):
         mel_basis = torch.as_tensor(
             torch.nn.functional.pad(mel_basis, (0, 1), mode="constant", value=0), device=x.device
         )
-        with torch.amp.autocast("cuda", enabled=False):
+        with torch.amp.autocast(x.device.type, enabled=False):
             melspec = torch.matmul(mel_basis, x)
 
         melspec = (melspec + 0.00001).log()

--- a/src/deepaudiox/schemas/types.py
+++ b/src/deepaudiox/schemas/types.py
@@ -5,3 +5,6 @@ BackboneName = Literal["beats", "passt", "mobilenet_05_as", "mobilenet_10_as", "
 
 PoolingName = Literal["gap", "simpool", "ep"]
 """Supported pooling layer names."""
+
+DeviceName = Literal["cuda", "mps", "cpu"]
+"""Supported device names."""

--- a/src/deepaudiox/utils/training_utils.py
+++ b/src/deepaudiox/utils/training_utils.py
@@ -11,6 +11,7 @@ from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import Subset
 
 from deepaudiox.datasets.audio_classification_dataset import AudioClassificationDataset
+from deepaudiox.schemas.types import DeviceName
 
 
 def get_logger() -> logging.Logger:
@@ -81,33 +82,57 @@ def get_class_mapping_from_dir(root_dir: str) -> dict[str, int]:
     return class_mapping
 
 
-def get_device(device_index: int | None = None) -> torch.device:
-    """Returns the best available device for PyTorch computations.
+def get_device(device: DeviceName = "cuda", device_index: int | None = None) -> torch.device:
+    """Returns a PyTorch device based on the user's choice.
 
     Args:
-        device_index (int | None): The GPU device index to use. If None, uses the default GPU if available.
+        device (DeviceName): The device to use. One of ``"cuda"``, ``"mps"``, or ``"cpu"``.
+            Defaults to ``"cuda"``.
+        device_index (int | None): The GPU device index. Only applicable when ``device="cuda"``.
+            If ``None``, uses the default CUDA device.
 
     Returns:
         torch.device
+
+    Raises:
+        ValueError: If ``device="cuda"`` but CUDA is not available.
+        ValueError: If ``device="cuda"`` and ``device_index`` is out of range.
+        ValueError: If ``device="mps"`` but MPS is not available.
+        ValueError: If ``device_index`` is provided for a non-CUDA device.
     """
-    if torch.cuda.is_available():
+    if device == "cuda":
+        if not torch.cuda.is_available():
+            raise ValueError("CUDA is not available on this machine.")
         if device_index is not None and (device_index < 0 or device_index >= torch.cuda.device_count()):
             raise ValueError(f"Invalid device_index {device_index}. Available GPU count: {torch.cuda.device_count()}")
         if device_index is not None:
-            device = torch.device(f"cuda:{device_index}")
+            torch_device = torch.device(f"cuda:{device_index}")
             print(f"Using GPU: {torch.cuda.get_device_name(device_index)}")
         else:
-            device = torch.device("cuda")
+            torch_device = torch.device("cuda")
             print(f"Using GPU: {torch.cuda.get_device_name(0)}")
+    elif device == "mps":
+        if not torch.backends.mps.is_available():
+            raise ValueError("MPS is not available on this machine.")
+        if device_index is not None:
+            raise ValueError("device_index is not supported for MPS. Apple Silicon has a single GPU.")
+        torch_device = torch.device("mps")
+        print("Using MPS (Apple Silicon GPU)")
     else:
-        device = torch.device("cpu")
-        print("Using CPU (no GPU available)")
+        if device_index is not None:
+            print("Warning: device_index is ignored when device='cpu'.")
+        torch_device = torch.device("cpu")
+        print("Using CPU")
 
-    return device
+    return torch_device
 
 
 def pad_collate_fn(batch) -> dict:
     """Collate function that pads variable-length audio tensors in a batch.
+
+    Uses ``torch.stack`` when all waveforms in the batch have the same length
+    (e.g. when ``segment_duration`` is set), and falls back to ``pad_sequence``
+    for variable-length batches.
 
     Args:
         batch (list of dict): Each dict contains 'feature', 'y_true', and 'class_name'.
@@ -115,13 +140,14 @@ def pad_collate_fn(batch) -> dict:
     Returns:
         dict[str, torch.Tensor | list[str]]: Batched and padded tensors.
     """
-    # Extract data
     features = [torch.from_numpy(item["feature"]) for item in batch]
     labels = torch.tensor([item["y_true"] for item in batch], dtype=torch.long)
     class_names = [item["class_name"] for item in batch]
 
-    # Stack into a single batch tensor with padding zeros on right to max_len
-    batch_features = pad_sequence(features, batch_first=True)
+    if len({f.shape[0] for f in features}) == 1:
+        batch_features = torch.stack(features)
+    else:
+        batch_features = pad_sequence(features, batch_first=True)
 
     return {"feature": batch_features, "y_true": labels, "class_name": class_names}
 

--- a/tests/test_deepaudiox.py
+++ b/tests/test_deepaudiox.py
@@ -18,6 +18,17 @@ VALIDATION_DIR = Path(__file__).parent / "testing_dataset" / "validation"
 TEST_DIR = Path(__file__).parent / "testing_dataset" / "test"
 
 
+def get_test_device() -> str:
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+TEST_DEVICE = get_test_device()
+
+
 @pytest.fixture(scope="session")
 def file_to_class_mapping():
     return {
@@ -221,6 +232,7 @@ def test_training_loop():
         num_workers=4,
         batch_size=16,
         path_to_checkpoint="testing_checkpoint.pt",
+        device=TEST_DEVICE,
     )
 
     trainer.train()
@@ -258,7 +270,7 @@ def test_evaluation_loop():
     model = dax.AudioClassifier.from_checkpoint(str(path_to_checkpoint))
 
     evaluator = dax.Evaluator(
-        test_dset=test_dataset, model=model, num_workers=4, batch_size=16, class_mapping=class_mapping
+        test_dset=test_dataset, model=model, num_workers=4, batch_size=16, class_mapping=class_mapping, device=TEST_DEVICE
     )
 
     evaluator.evaluate()

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "deepaudio-x"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "librosa" },


### PR DESCRIPTION
<h2>Summary</h2>
<p>
  This PR adds explicit device selection support (<code>"cuda"</code>,
  <code>"mps"</code>, <code>"cpu"</code>) across the training and evaluation
  pipelines, enabling users on Apple Silicon to leverage the MPS backend.
  It also includes targeted DataLoader efficiency improvements.
</p>

<h3>Device Selection</h3>
<ul>
  <li>
    Added <code>DeviceName = Literal["cuda", "mps", "cpu"]</code> type alias
    to <code>schemas/types.py</code>.
  </li>
  <li>
    Refactored <code>get_device()</code> to accept an explicit
    <code>device</code> argument instead of auto-detecting. Raises a clear
    <code>ValueError</code> for unavailable or misconfigured devices
    (e.g. CUDA not available, invalid <code>device_index</code>,
    <code>device_index</code> passed for MPS).
  </li>
  <li>
    Exposed <code>device</code> and <code>device_index</code> parameters on
    both <code>Trainer</code> and <code>Evaluator</code>. The
    <code>device_index</code> is only applicable when <code>device="cuda"</code>.
  </li>
  <li>
    Fixed hardcoded <code>"cuda"</code> string in PaSST's mel spectrogram
    <code>autocast</code> guard — replaced with <code>x.device.type</code>
    so it works correctly on any device.
  </li>
</ul>

<h3>DataLoader Efficiency</h3>
<ul>
  <li>
    <code>pin_memory</code> is now conditional on <code>device.type == "cuda"</code>
    in both <code>Trainer</code> and <code>Evaluator</code> — avoids unsupported
    behavior on MPS and CPU.
  </li>
  <li>
    Added <code>persistent_workers=True</code> (when <code>num_workers &gt; 0</code>)
    to all DataLoaders — eliminates worker process spawn/kill overhead at every
    epoch boundary.
  </li>
  <li>
    Optimized <code>pad_collate_fn</code> to use <code>torch.stack</code> when
    all waveforms in a batch have the same length (e.g. when
    <code>segment_duration</code> is set), falling back to
    <code>pad_sequence</code> for variable-length batches.
  </li>
</ul>

<h3>Documentation</h3>
<ul>
  <li>
    Updated README training and evaluation examples and parameter tables to
    document the new <code>device</code> parameter with all supported options.
  </li>
</ul>
