### PR TITLE
Issue #65 load weights always on cpu and remove unused parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepaudio-x"
-version = "0.4.4"
+version = "0.4.5"
 description = "DeepAudio-X: Self-supervised audio toolkit for audio classification and beyond."
 authors = [
   { name = "Christos Nikou", email = "chrisnick92@gmail.com" }, 

--- a/src/deepaudiox/__init__.py
+++ b/src/deepaudiox/__init__.py
@@ -2,7 +2,7 @@
 This page provides the core API reference for DeepAudioX.
 """
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 from deepaudiox.datasets.audio_classification_dataset import (  # noqa: F401
     AudioClassificationDataset,

--- a/src/deepaudiox/modules/constructors.py
+++ b/src/deepaudiox/modules/constructors.py
@@ -159,7 +159,7 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
             >>> backbone = Backbone.from_checkpoint("checkpoint.pt")
             >>> print(backbone.config)
         """
-        ckpt = torch.load(path, weights_only=False)
+        ckpt = torch.load(path, weights_only=True, map_location="cpu")
         if ckpt["config"].get("backbone") is None:
             raise ValueError(
                 "Cannot reconstruct model from checkpoint: a custom BaseBackbone instance was used. "
@@ -322,7 +322,7 @@ class AudioClassifierConstructor(BaseAudioClassifier, BackbonePoolingResolverMix
             >>> model = AudioClassifier.from_checkpoint("checkpoint.pt")
             >>> print(model.config)
         """
-        ckpt = torch.load(path, weights_only=False)
+        ckpt = torch.load(path, weights_only=True, map_location="cpu")
         if ckpt["config"].get("backbone") is None:
             raise ValueError(
                 "Cannot reconstruct model from checkpoint: a custom BaseBackbone instance was used. "

--- a/src/deepaudiox/modules/constructors.py
+++ b/src/deepaudiox/modules/constructors.py
@@ -176,16 +176,15 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
             waveforms (torch.Tensor): Input waveforms of shape (B, T).
 
         Returns:
-            torch.Tensor: Model-specific feature map, either (B, N, D) or (B, D, H, W).
+            torch.Tensor: Model-specific input features.
         """
         return self.backbone.extract_features(waveforms)
 
-    def forward(self, x: torch.Tensor, padding_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through the backbone.
 
         Args:
             x (torch.Tensor): Input waveforms of shape (B, T).
-            padding_mask (torch.Tensor or None): Optional padding mask (unused).
 
         Returns:
             torch.Tensor: Backbone feature map of shape (B, N, D) or (B, D, H, W).
@@ -200,12 +199,11 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
         """
         return self.backbone.forward_pipeline(x)
 
-    def forward_with_pooling(self, x: torch.Tensor, padding_mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward_with_pooling(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through backbone and pooling (with optional normalization).
 
         Args:
             x (torch.Tensor): Input waveforms of shape (B, T).
-            padding_mask (torch.Tensor or None): Optional padding mask (unused).
 
         Returns:
             torch.Tensor: Pooled tensor of shape (B, D).

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "deepaudio-x"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "librosa" },


### PR DESCRIPTION
<h2>Checkpoint Loading Improvements</h2>

<ul>
  <li>
    <strong>Safe checkpoint loading:</strong> both <code>Backbone.from_checkpoint</code> and
    <code>AudioClassifier.from_checkpoint</code> now use
    <code>map_location="cpu"</code> and <code>weights_only=True</code>.
    Weights always deserialize to CPU regardless of the device they were saved on,
    letting the caller decide where to move the model. <code>weights_only=True</code>
    prevents arbitrary code execution during unpickling.
  </li>
  <li>
    <strong>Removed unused <code>padding_mask</code> argument</strong> from
    <code>BackboneConstructor.forward</code> and <code>forward_with_pooling</code>.
  </li>
  <li>Bumped version <code>v0.4.4 → v0.4.5</code>.</li>
</ul>
