### PR TITLE
(issue #67) make early_stopping optional; cpu default device for trainer, evaluator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepaudio-x"
-version = "0.4.5"
+version = "0.4.6"
 description = "DeepAudio-X: Self-supervised audio toolkit for audio classification and beyond."
 authors = [
   { name = "Christos Nikou", email = "chrisnick92@gmail.com" }, 

--- a/src/deepaudiox/__init__.py
+++ b/src/deepaudiox/__init__.py
@@ -2,7 +2,7 @@
 This page provides the core API reference for DeepAudioX.
 """
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 from deepaudiox.datasets.audio_classification_dataset import (  # noqa: F401
     AudioClassificationDataset,

--- a/src/deepaudiox/callbacks/early_stopper.py
+++ b/src/deepaudiox/callbacks/early_stopper.py
@@ -54,4 +54,7 @@ class EarlyStopper(BaseCallback):
             trainer.state.early_stop = True
             self.logger.info("[EARLY STOPPING] Patience exceeded, early stoping ...")
 
+        # Update current patience in trainer's state
+        trainer.state.current_patience = self.elapsed_epochs
+
         return

--- a/src/deepaudiox/loops/evaluator.py
+++ b/src/deepaudiox/loops/evaluator.py
@@ -51,7 +51,7 @@ class Evaluator:
         class_mapping: dict,
         batch_size: int = 16,
         num_workers: int = 4,
-        device: DeviceName = "cuda",
+        device: DeviceName = "cpu",
         device_index: int | None = None,
         verbose: bool = True,
     ):
@@ -64,7 +64,7 @@ class Evaluator:
             batch_size (int, optional): The batch size for Python Data Loaders. Defaults to 16.
             num_workers (int, optional): The number of workers for Python Data Loaders. Defaults to 4.
             device (DeviceName): The device to use for evaluation. One of ``"cuda"``, ``"mps"``, or ``"cpu"``.
-                Defaults to ``"cuda"``.
+                Defaults to ``"cpu"``.
             device_index (int | None): The GPU device index. Only applicable when ``device="cuda"``.
                 If ``None``, uses the default CUDA device.
             verbose (bool): If True, prints the classification report, confusion matrix, and average

--- a/src/deepaudiox/loops/trainer.py
+++ b/src/deepaudiox/loops/trainer.py
@@ -9,6 +9,7 @@ from torch.optim.lr_scheduler import LRScheduler, ReduceLROnPlateau
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from deepaudiox.callbacks.base_callback import BaseCallback
 from deepaudiox.callbacks.checkpointer import Checkpointer
 from deepaudiox.callbacks.early_stopper import EarlyStopper
 from deepaudiox.datasets.audio_classification_dataset import AudioClassificationDataset
@@ -35,6 +36,7 @@ class State:
     train_loss: list[float] = field(default_factory=list)
     validation_loss: list[float] = field(default_factory=list)
     early_stop: bool = False
+    current_patience: int = 0
 
 
 class Trainer:
@@ -70,11 +72,11 @@ class Trainer:
         loss_function: nn.Module | None = None,
         train_ratio: float = 0.8,
         epochs: int = 100,
-        patience: int = 15,
+        patience: int | None = None,
         num_workers: int = 4,
         batch_size: int = 16,
         path_to_checkpoint: str = "checkpoint.pt",
-        device: DeviceName = "cuda",
+        device: DeviceName = "cpu",
         device_index: int | None = None,
         verbose: bool = True,
     ):
@@ -91,12 +93,12 @@ class Trainer:
             loss_function (nn.Module | None): The loss function used for training. Uses CrossEntropy if None.
             train_ratio (float, optional): The ratio of the train split when validation_dset is None. Defaults to 0.8.
             epochs (int, optional): The maximum number of training epochs. Defaults to 100.
-            patience (int, optional): The maximum number of epochs with no decrease in loss. Defaults to 15.
+            patience (int | None): Epochs to wait without loss improvement before stopping. Disabled if None.
             num_workers (int, optional): The number of workers for Python Data Loaders. Defaults to 4.
             batch_size (int, optional): The batch size for Python Data Loaders. Defaults to 16.
             path_to_checkpoint (str, optional): The path to the saved model checpoint. Defaults to "checkpoint.pt".
             device (DeviceName): The device to use for training. One of ``"cuda"``, ``"mps"``, or ``"cpu"``.
-                Defaults to ``"cuda"``.
+                Defaults to ``"cpu"``.
             device_index (int | None): The GPU device index. Only applicable when ``device="cuda"``.
                 If ``None``, uses the default CUDA device.
             verbose (bool): If True, logs epoch-level artifacts (loss, time). If False, only
@@ -141,11 +143,11 @@ class Trainer:
         self.scheduler = lr_scheduler or ReduceLROnPlateau(self.optimizer, "min")
         self.loss_function = loss_function or nn.CrossEntropyLoss()
 
-        # Configure callbacks
-        self.callbacks = [
-            Checkpointer(path_to_checkpoint=path_to_checkpoint, logger=self.logger),
-            EarlyStopper(patience=patience, logger=self.logger),
-        ]
+        # Configure callbacks — Checkpointer must precede EarlyStopper (updates lowest_loss first)
+        self.callbacks: list[BaseCallback] = [Checkpointer(path_to_checkpoint=path_to_checkpoint, logger=self.logger)]
+        if patience:
+            self.callbacks.append(EarlyStopper(patience=patience, logger=self.logger))
+
         self._epoch_start_time: float = 0.0
 
     def train_step(self) -> float:

--- a/src/deepaudiox/utils/training_utils.py
+++ b/src/deepaudiox/utils/training_utils.py
@@ -82,12 +82,12 @@ def get_class_mapping_from_dir(root_dir: str) -> dict[str, int]:
     return class_mapping
 
 
-def get_device(device: DeviceName = "cuda", device_index: int | None = None) -> torch.device:
+def get_device(device: DeviceName = "cpu", device_index: int | None = None) -> torch.device:
     """Returns a PyTorch device based on the user's choice.
 
     Args:
         device (DeviceName): The device to use. One of ``"cuda"``, ``"mps"``, or ``"cpu"``.
-            Defaults to ``"cuda"``.
+            Defaults to ``"cpu"``.
         device_index (int | None): The GPU device index. Only applicable when ``device="cuda"``.
             If ``None``, uses the default CUDA device.
 
@@ -102,7 +102,7 @@ def get_device(device: DeviceName = "cuda", device_index: int | None = None) -> 
     """
     if device == "cuda":
         if not torch.cuda.is_available():
-            raise ValueError("CUDA is not available on this machine.")
+            raise ValueError("CUDA is not available on this machine. Use device='cpu' or device='mps' instead.")
         if device_index is not None and (device_index < 0 or device_index >= torch.cuda.device_count()):
             raise ValueError(f"Invalid device_index {device_index}. Available GPU count: {torch.cuda.device_count()}")
         if device_index is not None:
@@ -113,7 +113,7 @@ def get_device(device: DeviceName = "cuda", device_index: int | None = None) -> 
             print(f"Using GPU: {torch.cuda.get_device_name(0)}")
     elif device == "mps":
         if not torch.backends.mps.is_available():
-            raise ValueError("MPS is not available on this machine.")
+            raise ValueError("MPS is not available on this machine. Use device='cpu' instead.")
         if device_index is not None:
             raise ValueError("device_index is not supported for MPS. Apple Silicon has a single GPU.")
         torch_device = torch.device("mps")
@@ -122,7 +122,7 @@ def get_device(device: DeviceName = "cuda", device_index: int | None = None) -> 
         if device_index is not None:
             print("Warning: device_index is ignored when device='cpu'.")
         torch_device = torch.device("cpu")
-        print("Using CPU")
+        print("Using CPU.")
 
     return torch_device
 

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "deepaudio-x"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "librosa" },


### PR DESCRIPTION
<h2>Make Early Stopping Optional & Add <code>current_patience</code> to Trainer State</h2>

<h3>Overview</h3>
<p>
  Early stopping is now opt-in rather than always active, <code>current_patience</code> is
  exposed on <code>trainer.state</code> for runtime introspection, and the default device
  for <code>Trainer</code> and <code>Evaluator</code> is changed to <code>"cpu"</code>
  to avoid errors on machines without a GPU.
</p>

<h3>Changes</h3>

<h4>Early Stopping — opt-in</h4>
<ul>
  <li><code>patience</code> now defaults to <code>None</code> (previously <code>15</code>).
    When <code>None</code>, <code>EarlyStopper</code> is not added to the callback list and
    training always runs for the full number of epochs.</li>
  <li><code>EarlyStopper</code> is only instantiated when <code>patience</code> is explicitly set.</li>
  <li>Callback list typed as <code>list[BaseCallback]</code> to correctly accommodate both
    <code>Checkpointer</code> and <code>EarlyStopper</code>.</li>
</ul>

<h4><code>current_patience</code> on <code>State</code></h4>
<ul>
  <li><code>State.current_patience: int = 0</code> added — updated by <code>EarlyStopper</code>
    after each epoch, allowing callers to monitor patience consumption via <code>trainer.state.current_patience</code>.</li>
</ul>

<h4>Default device changed to <code>"cpu"</code></h4>
<ul>
  <li><code>Trainer</code>, <code>Evaluator</code>, and <code>get_device</code> now default to
    <code>device="cpu"</code>. Previously defaulting to <code>"cuda"</code> caused an immediate
    <code>ValueError</code> on CPU-only machines before any training could start.</li>
  <li><code>get_device</code> error messages updated to suggest the correct alternative device.</li>
</ul>
