### PR TITLE
(Issue #69) Modified from_checkpoint method

### DIFF
--- a/docs/source/tutorials/Tutorial 02 - Loading Data from Unstructured Directory.ipynb
+++ b/docs/source/tutorials/Tutorial 02 - Loading Data from Unstructured Directory.ipynb
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4633ec79",
    "metadata": {},
    "outputs": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "adc51b1c",
    "metadata": {},
    "outputs": [
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "b3f8bdd9",
    "metadata": {},
    "outputs": [],
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "25f562c0",
    "metadata": {},
    "outputs": [
@@ -357,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "5faa9122",
    "metadata": {},
    "outputs": [],

--- a/src/deepaudiox/modules/constructors.py
+++ b/src/deepaudiox/modules/constructors.py
@@ -49,7 +49,7 @@ class BackbonePoolingResolverMixin:
                 downloader = Downloader()
                 ckpt_path = downloader.download_checkpoint(backbone)
                 ckpt = load_checkpoint(ckpt_path)
-                model.load_state_dict(ckpt)
+                model.load_state_dict(ckpt, strict=False)
         else:
             model = backbone
 
@@ -165,7 +165,7 @@ class BackboneConstructor(nn.Module, BackbonePoolingResolverMixin):
                 "Cannot reconstruct model from checkpoint: a custom BaseBackbone instance was used. "
                 "Instantiate the model manually and call model.load_state_dict(torch.load(path)['state_dict'])."
             )
-        model = cls(**ckpt["config"])
+        model = cls(**{**ckpt["config"], "pretrained": False})
         model.load_state_dict(ckpt["state_dict"])
         return model
 
@@ -326,7 +326,7 @@ class AudioClassifierConstructor(BaseAudioClassifier, BackbonePoolingResolverMix
                 "Cannot reconstruct model from checkpoint: a custom BaseBackbone instance was used. "
                 "Instantiate the model manually and call model.load_state_dict(torch.load(path)['state_dict'])."
             )
-        model = cls(**ckpt["config"])
+        model = cls(**{**ckpt["config"], "pretrained": False})
         model.load_state_dict(ckpt["state_dict"])
         return model
 

--- a/tests/test_deepaudiox.py
+++ b/tests/test_deepaudiox.py
@@ -270,7 +270,12 @@ def test_evaluation_loop():
     model = dax.AudioClassifier.from_checkpoint(str(path_to_checkpoint))
 
     evaluator = dax.Evaluator(
-        test_dset=test_dataset, model=model, num_workers=4, batch_size=16, class_mapping=class_mapping, device=TEST_DEVICE
+        test_dset=test_dataset, 
+        model=model, 
+        num_workers=4,
+        batch_size=16,
+        class_mapping=class_mapping, 
+        device=TEST_DEVICE
     )
 
     evaluator.evaluate()


### PR DESCRIPTION
@ChrisNick92 

# PR Summary
In this PR, all **from_checkpoint()** methods were modified so weights of pre-trained backbones are not initialized twice.

# Changes

- **[constructors.py](src/deepaudiox/modules/constructors.py)**: 
    - **BackboneConstructor.from_checkpoint()**: _pretrained_ is now ovewritten to `False`
    -  **AudioClassifierConstructor.from_checkpoint()**: _pretrained_ is also ovewritten to `False`
    -  **BackbonePoolingResolverMixin._resolve_backbone()**: `strict=False` was added to _model.load_state_dict(ckpt)_ to avoid error caused by additional classifier weights present in the pre-trained MobileNet checkpoint.
    
<img width="1068" height="575" alt="Στιγμιότυπο οθόνης 2026-06-08 093716" src="https://github.com/user-attachments/assets/d4974685-f54a-4b82-a492-feef28eb9e26" />

# Checklist
- [x] Formatted code with Ruff
- [x] Deleted cached data and tested model initialization from checkpoint. Everything works fine.
- [x] Performed successfully all tests. 